### PR TITLE
選手個人成績ページを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import HomePage from './components/pages/HomePage';
 import BattingPage from './components/pages/BattingPage';
 import PitchingPage from './components/pages/PitchingPage';
 import PlayersPage from './components/pages/PlayersPage';
+import PlayerPage from './components/pages/PlayerPage';
 
 const App: React.FC = () => {
   return (
@@ -16,6 +17,7 @@ const App: React.FC = () => {
         <Route path="/batting" component={BattingPage} exact />
         <Route path="/pitching" component={PitchingPage} exact />
         <Route path="/players" component={PlayersPage} exact />
+        <Route path="/player/:id" component={PlayerPage} exact />
       </Switch>
     </Router>
   );

--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -179,6 +179,8 @@ const BattingPage: React.FC = () => {
         initSelect={'2020'}
         selectLabel={'年'}
         mainLink={false}
+        linkValues={new Map<string, string>()}
+        path={''}
       />
       <TablePages
         title={'シーズン打撃成績(パ)'}
@@ -190,6 +192,8 @@ const BattingPage: React.FC = () => {
         initSelect={'2020'}
         selectLabel={'年'}
         mainLink={false}
+        linkValues={new Map<string, string>()}
+        path={''}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -171,8 +171,8 @@ const BattingPage: React.FC = () => {
     <GenericTemplate title="チーム打撃成績ページ">
       <TablePages
         title={'シーズン打撃成績(セ)'}
-        getTeamDataList={getBattingCentralDataList}
-        teamDatas={centralBattingDatas}
+        getDataList={getBattingCentralDataList}
+        datas={centralBattingDatas}
         selects={years}
         headCells={headCells}
         initSorted={'battingAverage'}
@@ -182,8 +182,8 @@ const BattingPage: React.FC = () => {
       />
       <TablePages
         title={'シーズン打撃成績(パ)'}
-        getTeamDataList={getBattingPacificDataList}
-        teamDatas={pacificBattingDatas}
+        getDataList={getBattingPacificDataList}
+        datas={pacificBattingDatas}
         selects={years}
         headCells={headCells}
         initSorted={'battingAverage'}

--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -178,6 +178,7 @@ const BattingPage: React.FC = () => {
         initSorted={'battingAverage'}
         initSelect={'2020'}
         selectLabel={'年'}
+        mainLink={false}
       />
       <TablePages
         title={'シーズン打撃成績(パ)'}
@@ -188,6 +189,7 @@ const BattingPage: React.FC = () => {
         initSorted={'battingAverage'}
         initSelect={'2020'}
         selectLabel={'年'}
+        mainLink={false}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -167,6 +167,7 @@ const PitchingPage: React.FC = () => {
         initSorted={'earnedRunAverage'}
         initSelect={'2020'}
         selectLabel={'年'}
+        mainLink={false}
       />
       <TablePages
         title={'シーズン投手成績(パ)'}
@@ -177,6 +178,7 @@ const PitchingPage: React.FC = () => {
         initSorted={'earnedRunAverage'}
         initSelect={'2020'}
         selectLabel={'年'}
+        mainLink={false}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -160,8 +160,8 @@ const PitchingPage: React.FC = () => {
     <GenericTemplate title="チーム投手成績ページ">
       <TablePages
         title={'シーズン投手成績(セ)'}
-        getTeamDataList={getCentralPitchingDataList}
-        teamDatas={centralDatas}
+        getDataList={getCentralPitchingDataList}
+        datas={centralDatas}
         selects={years}
         headCells={headCells}
         initSorted={'earnedRunAverage'}
@@ -171,8 +171,8 @@ const PitchingPage: React.FC = () => {
       />
       <TablePages
         title={'シーズン投手成績(パ)'}
-        getTeamDataList={getPacificPitchingDataList}
-        teamDatas={pacificDatas}
+        getDataList={getPacificPitchingDataList}
+        datas={pacificDatas}
         selects={years}
         headCells={headCells}
         initSorted={'earnedRunAverage'}

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -168,6 +168,8 @@ const PitchingPage: React.FC = () => {
         initSelect={'2020'}
         selectLabel={'年'}
         mainLink={false}
+        linkValues={new Map<string, string>()}
+        path={''}
       />
       <TablePages
         title={'シーズン投手成績(パ)'}
@@ -179,6 +181,8 @@ const PitchingPage: React.FC = () => {
         initSelect={'2020'}
         selectLabel={'年'}
         mainLink={false}
+        linkValues={new Map<string, string>()}
+        path={''}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import GenericTemplate from '../templates/GenericTemplate';
+import TablePages, { HeadCell } from './TablePages';
+import axios from 'axios';
+
+type PageProps = RouteComponentProps<{ id: string }>;
+
+interface PlayerData {
+  main: string;
+}
+
+const headCells: HeadCell[] = [
+  { id: 'main', numeric: false, disablePadding: true, label: '選手名' },
+];
+
+const PlayerPage: React.FC<PageProps> = (props) => {
+  const [playerDates, setPlayerDates] = useState<PlayerData[]>([]);
+
+  const getPlayerDatas = async () => {
+    const playerID = props.match.params.id;
+    const result = await axios.get(`http://localhost:8081/team/player/${playerID}`);
+  };
+
+  useEffect(() => {
+    (async () => {
+      getPlayerDatas();
+    })();
+  }, []);
+
+  return (
+    <GenericTemplate title="打撃成績">
+      <TablePages
+        title={'打撃成績'}
+        getDataList={getPlayerDatas}
+        datas={playerDates}
+        selects={[]}
+        headCells={headCells}
+        initSorted={'main'}
+        initSelect={''}
+        selectLabel={''}
+        mainLink={false}
+        linkValues={new Map<string, string>()}
+        path={''}
+      />
+    </GenericTemplate>
+  );
+};
+
+export default PlayerPage;

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -3,23 +3,134 @@ import { RouteComponentProps } from 'react-router-dom';
 import GenericTemplate from '../templates/GenericTemplate';
 import TablePages, { HeadCell } from './TablePages';
 import axios from 'axios';
+import _ from 'lodash';
 
 type PageProps = RouteComponentProps<{ id: string }>;
 
-interface PlayerData {
+interface BattingDate {
   main: string;
+  team: string;
+  atBat: number;
+  onBasePercentage: number;
+  battingAverage: number;
+  sluggingPercentage: number;
+  homeRun: number;
+  strikeOut: number;
+  groundedIntoDoublePlay: number;
 }
 
-const headCells: HeadCell[] = [
-  { id: 'main', numeric: false, disablePadding: true, label: '選手名' },
+const batterHeadCells: HeadCell[] = [
+  { id: 'main', numeric: false, disablePadding: true, label: '年' },
+  { id: 'team', numeric: false, disablePadding: true, label: 'チーム' },
+  { id: 'atBat', numeric: true, disablePadding: true, label: '打数' },
+  { id: 'onBasePercentage', numeric: true, disablePadding: true, label: '出塁率' },
+  { id: 'battingAverage', numeric: true, disablePadding: true, label: '打率' },
+  { id: 'sluggingPercentage', numeric: true, disablePadding: true, label: '長打率' },
+  { id: 'homeRun', numeric: true, disablePadding: true, label: '本塁打' },
+  { id: 'strikeOut', numeric: true, disablePadding: true, label: '三振' },
+  { id: 'groundedIntoDoublePlay', numeric: true, disablePadding: true, label: '併殺打' },
 ];
 
+function createBattingDatas(
+  battingList: {
+    Year: string;
+    Team: string;
+    AtBat: string;
+    OnBasePercentage: string;
+    BattingAverage: string;
+    SluggingPercentage: string;
+    HomeRun: string;
+    StrikeOut: string;
+    GroundedIntoDoublePlay: string;
+  }[]
+) {
+  const battings: BattingDate[] = [];
+  battingList.forEach((batting) => {
+    battings.push({
+      main: batting.Year === 'nan' ? '通算' : batting.Year,
+      team: batting.Team,
+      atBat: Number(batting.AtBat),
+      onBasePercentage: Number(batting.OnBasePercentage),
+      battingAverage: Number(batting.BattingAverage),
+      sluggingPercentage: Number(batting.SluggingPercentage),
+      homeRun: Number(batting.HomeRun),
+      strikeOut: Number(batting.StrikeOut),
+      groundedIntoDoublePlay: Number(batting.GroundedIntoDoublePlay),
+    });
+  });
+  return battings;
+}
+
+interface PitchingDate {
+  main: string;
+  team: string;
+  piched: number;
+  inningsPitched: number;
+  earnedRunAverage: number;
+  batter: number;
+  strikeOut: number;
+  homeRun: number;
+  baseOnBalls: number;
+  hitByPitches: number;
+}
+
+const pitcherHeadCells: HeadCell[] = [
+  { id: 'main', numeric: false, disablePadding: true, label: '年' },
+  { id: 'team', numeric: false, disablePadding: true, label: 'チーム' },
+  { id: 'piched', numeric: true, disablePadding: true, label: '登板' },
+  { id: 'inningsPitched', numeric: true, disablePadding: true, label: '投球回' },
+  { id: 'earnedRunAverage', numeric: true, disablePadding: true, label: '防御率' },
+  { id: 'batter', numeric: true, disablePadding: true, label: '打者' },
+  { id: 'strikeOut', numeric: true, disablePadding: true, label: '三振' },
+  { id: 'homeRun', numeric: true, disablePadding: true, label: '被本塁打' },
+  { id: 'baseOnBalls', numeric: true, disablePadding: true, label: '四球' },
+  { id: 'hitByPitches', numeric: true, disablePadding: true, label: '死球' },
+];
+
+function createPitchingDatas(
+  pitchingList: {
+    Year: string;
+    Team: string;
+    Piched: string;
+    InningsPitched: string;
+    EarnedRunAverage: string;
+    Batter: string;
+    StrikeOut: string;
+    HomeRun: string;
+    BaseOnBalls: string;
+    HitByPitches: string;
+  }[]
+) {
+  const pitchings: PitchingDate[] = [];
+  pitchingList.forEach((pitching) => {
+    pitchings.push({
+      main: pitching.Year === 'nan' ? '通算' : pitching.Year,
+      team: pitching.Team,
+      piched: Number(pitching.Piched),
+      inningsPitched: Number(pitching.InningsPitched),
+      earnedRunAverage: Number(pitching.EarnedRunAverage),
+      batter: Number(pitching.Batter),
+      strikeOut: Number(pitching.StrikeOut),
+      homeRun: Number(pitching.HomeRun),
+      baseOnBalls: Number(pitching.BaseOnBalls),
+      hitByPitches: Number(pitching.HitByPitches),
+    });
+  });
+  return pitchings;
+}
+
 const PlayerPage: React.FC<PageProps> = (props) => {
-  const [playerDates, setPlayerDates] = useState<PlayerData[]>([]);
+  const [playerName, setPlayerName] = useState<string>('');
+  const [battingDates, setBattingDates] = useState<BattingDate[]>([]);
+  const [pitchingDates, setPitchingDates] = useState<PitchingDate[]>([]);
 
   const getPlayerDatas = async () => {
     const playerID = props.match.params.id;
-    const result = await axios.get(`http://localhost:8081/team/player/${playerID}`);
+    const result = await axios.get(`http://localhost:8081/player/${playerID}`);
+    const { career, batting, pitching } = result.data;
+    setPlayerName(career.Name);
+    setBattingDates(_.isEmpty(batting) ? [] : createBattingDatas(batting));
+    setPitchingDates(_.isEmpty(pitching) ? [] : createPitchingDatas(pitching));
   };
 
   useEffect(() => {
@@ -29,13 +140,26 @@ const PlayerPage: React.FC<PageProps> = (props) => {
   }, []);
 
   return (
-    <GenericTemplate title="打撃成績">
+    <GenericTemplate title={playerName}>
       <TablePages
         title={'打撃成績'}
         getDataList={getPlayerDatas}
-        datas={playerDates}
+        datas={battingDates}
         selects={[]}
-        headCells={headCells}
+        headCells={batterHeadCells}
+        initSorted={'main'}
+        initSelect={''}
+        selectLabel={''}
+        mainLink={false}
+        linkValues={new Map<string, string>()}
+        path={''}
+      />
+      <TablePages
+        title={'投手成績'}
+        getDataList={getPlayerDatas}
+        datas={pitchingDates}
+        selects={[]}
+        headCells={pitcherHeadCells}
         initSorted={'main'}
         initSelect={''}
         selectLabel={''}

--- a/frontend/src/components/pages/PlayersPage.tsx
+++ b/frontend/src/components/pages/PlayersPage.tsx
@@ -63,6 +63,19 @@ function createPlayerDates(
   return playerDateList;
 }
 
+function createPlayerIds(
+  careers: {
+    PlayerID: string;
+    Name: string;
+  }[]
+) {
+  const playerIdMap: Map<string, string> = new Map<string, string>();
+  careers.forEach((career) => {
+    playerIdMap.set(career.Name, career.PlayerID);
+  });
+  return playerIdMap;
+}
+
 function getTeamId(teamName: string) {
   for (const index in teamNameList) {
     if (teamNameList[index] === teamName) {
@@ -73,10 +86,12 @@ function getTeamId(teamName: string) {
 
 const PlayersPage: React.FC = () => {
   const [playerDates, setPlayerDates] = useState<PlayerDate[]>([]);
+  const [playerIdMap, setPlayerIds] = useState<Map<string, string>>(new Map<string, string>());
 
   const getPlayerList = async (teamName: string) => {
     const teamID = getTeamId(teamName);
     const result = await axios.get(`http://localhost:8081/team/careers/${teamID}/2020`);
+    setPlayerIds(createPlayerIds(result.data.careers));
     setPlayerDates(createPlayerDates(result.data.careers));
   };
 
@@ -98,6 +113,8 @@ const PlayersPage: React.FC = () => {
         initSelect={'Hawks'}
         selectLabel={'チーム'}
         mainLink={true}
+        linkValues={playerIdMap}
+        path={'/player/'}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/PlayersPage.tsx
+++ b/frontend/src/components/pages/PlayersPage.tsx
@@ -90,8 +90,8 @@ const PlayersPage: React.FC = () => {
     <GenericTemplate title="選手一覧ページ">
       <TablePages
         title={'選手一覧'}
-        getTeamDataList={getPlayerList}
-        teamDatas={playerDates}
+        getDataList={getPlayerList}
+        datas={playerDates}
         selects={teamNameList}
         headCells={headCells}
         initSorted={'main'}

--- a/frontend/src/components/pages/PlayersPage.tsx
+++ b/frontend/src/components/pages/PlayersPage.tsx
@@ -97,6 +97,7 @@ const PlayersPage: React.FC = () => {
         initSorted={'main'}
         initSelect={'Hawks'}
         selectLabel={'チーム'}
+        mainLink={true}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/SeasonPage.tsx
+++ b/frontend/src/components/pages/SeasonPage.tsx
@@ -157,8 +157,8 @@ const SeasonPage: React.FC = () => {
     <GenericTemplate title="チーム成績ページ">
       <TablePages
         title={'シーズン成績(セ)'}
-        getTeamDataList={getTeamCentralDataList}
-        teamDatas={centralTeamDatas}
+        getDataList={getTeamCentralDataList}
+        datas={centralTeamDatas}
         selects={years}
         headCells={headCells}
         initSorted={'winningRate'}
@@ -168,8 +168,8 @@ const SeasonPage: React.FC = () => {
       />
       <TablePages
         title={'シーズン成績(パ)'}
-        getTeamDataList={getTeamPacificDataList}
-        teamDatas={pacificTeamDatas}
+        getDataList={getTeamPacificDataList}
+        datas={pacificTeamDatas}
         selects={years}
         headCells={headCells}
         initSorted={'winningRate'}

--- a/frontend/src/components/pages/SeasonPage.tsx
+++ b/frontend/src/components/pages/SeasonPage.tsx
@@ -165,6 +165,8 @@ const SeasonPage: React.FC = () => {
         initSelect={'2020'}
         selectLabel={'年'}
         mainLink={false}
+        linkValues={new Map<string, string>()}
+        path={''}
       />
       <TablePages
         title={'シーズン成績(パ)'}
@@ -176,6 +178,8 @@ const SeasonPage: React.FC = () => {
         initSelect={'2020'}
         selectLabel={'年'}
         mainLink={false}
+        linkValues={new Map<string, string>()}
+        path={''}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/SeasonPage.tsx
+++ b/frontend/src/components/pages/SeasonPage.tsx
@@ -164,6 +164,7 @@ const SeasonPage: React.FC = () => {
         initSorted={'winningRate'}
         initSelect={'2020'}
         selectLabel={'年'}
+        mainLink={false}
       />
       <TablePages
         title={'シーズン成績(パ)'}
@@ -174,6 +175,7 @@ const SeasonPage: React.FC = () => {
         initSorted={'winningRate'}
         initSelect={'2020'}
         selectLabel={'年'}
+        mainLink={false}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/TablePages.tsx
+++ b/frontend/src/components/pages/TablePages.tsx
@@ -109,8 +109,8 @@ function Main(props: { mainLink: boolean; main: string; value: string }) {
 
 export default function TablePages(props: {
   title: string;
-  getTeamDataList: (year: string) => void;
-  teamDatas: { main: string }[];
+  getDataList: (year: string) => void;
+  datas: { main: string }[];
   selects: string[];
   headCells: HeadCell[];
   initSorted: string;
@@ -124,7 +124,7 @@ export default function TablePages(props: {
   const [orderBy, setOrderBy] = React.useState<string>(props.initSorted);
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setYear(event.target.value as string);
-    props.getTeamDataList(String(event.target.value));
+    props.getDataList(String(event.target.value));
   };
   const handleRequestSort = (event: React.MouseEvent<unknown>, property: string) => {
     const isAsc = orderBy === property && order === 'asc';
@@ -194,7 +194,7 @@ export default function TablePages(props: {
             </TableRow>
           </TableHead>
           <TableBody>
-            {stableSort(props.teamDatas, getComparator(order, orderBy)).map((teamData, index) => {
+            {stableSort(props.datas, getComparator(order, orderBy)).map((teamData, index) => {
               const labelId = `enhanced-table-checkbox-${index}`;
               return (
                 <TableRow hover tabIndex={-1} key={teamData.main}>

--- a/frontend/src/components/pages/TablePages.tsx
+++ b/frontend/src/components/pages/TablePages.tsx
@@ -107,6 +107,46 @@ function Main(props: { mainLink: boolean; main: string; value: string | undefine
   }
 }
 
+function Selectable(props: {
+  formControl: string;
+  selectLabel: string;
+  initSelect: string;
+  selects: string[];
+  handleChange:
+    | ((
+        event: React.ChangeEvent<{
+          name?: string | undefined;
+          value: unknown;
+        }>,
+        child: React.ReactNode
+      ) => void)
+    | undefined;
+}) {
+  if (!_.isEmpty(props.selects)) {
+    return (
+      <FormControl className={props.formControl}>
+        <InputLabel id="demo-simple-select-label">{props.selectLabel}</InputLabel>
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={props.initSelect}
+          onChange={props.handleChange}
+        >
+          {props.selects.map((select) => {
+            return (
+              <MenuItem key={select} value={select}>
+                {select}
+              </MenuItem>
+            );
+          })}
+        </Select>
+      </FormControl>
+    );
+  } else {
+    return <div></div>;
+  }
+}
+
 export default function TablePages(props: {
   title: string;
   getDataList: (year: string) => void;
@@ -149,23 +189,13 @@ export default function TablePages(props: {
               </Paper>
             </Grid>
             <Grid key={2} item>
-              <FormControl className={classes.formControl}>
-                <InputLabel id="demo-simple-select-label">{props.selectLabel}</InputLabel>
-                <Select
-                  labelId="demo-simple-select-label"
-                  id="demo-simple-select"
-                  value={initSelect}
-                  onChange={handleChange}
-                >
-                  {props.selects.map((select) => {
-                    return (
-                      <MenuItem key={select} value={select}>
-                        {select}
-                      </MenuItem>
-                    );
-                  })}
-                </Select>
-              </FormControl>
+              <Selectable
+                formControl={classes.formControl}
+                selectLabel={props.selectLabel}
+                initSelect={initSelect}
+                selects={props.selects}
+                handleChange={handleChange}
+              />
             </Grid>
           </Grid>
         </Typography>

--- a/frontend/src/components/pages/TablePages.tsx
+++ b/frontend/src/components/pages/TablePages.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { createStyles, lighten, makeStyles, Theme } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -90,6 +91,22 @@ export interface HeadCell {
   numeric: boolean;
 }
 
+function Main(props: { mainLink: boolean; main: string; value: string }) {
+  if (props.mainLink) {
+    return (
+      <Link
+        to={{
+          pathname: `/test/${props.value}`,
+        }}
+      >
+        {props.main}
+      </Link>
+    );
+  } else {
+    return <div>{props.main}</div>;
+  }
+}
+
 export default function TablePages(props: {
   title: string;
   getTeamDataList: (year: string) => void;
@@ -99,6 +116,7 @@ export default function TablePages(props: {
   initSorted: string;
   initSelect: string;
   selectLabel: string;
+  mainLink: boolean;
 }) {
   const classes = useStyles();
   const [initSelect, setYear] = React.useState(props.initSelect);
@@ -181,7 +199,7 @@ export default function TablePages(props: {
               return (
                 <TableRow hover tabIndex={-1} key={teamData.main}>
                   <TableCell component="th" id={labelId} scope="row" padding="none">
-                    {teamData.main}
+                    <Main mainLink={props.mainLink} main={teamData.main} value={'test'} />
                   </TableCell>
                   {_.map(teamData, (val, key) => {
                     if (key === 'main') {

--- a/frontend/src/components/pages/TablePages.tsx
+++ b/frontend/src/components/pages/TablePages.tsx
@@ -91,12 +91,12 @@ export interface HeadCell {
   numeric: boolean;
 }
 
-function Main(props: { mainLink: boolean; main: string; value: string }) {
+function Main(props: { mainLink: boolean; main: string; value: string | undefined; path: string }) {
   if (props.mainLink) {
     return (
       <Link
         to={{
-          pathname: `/test/${props.value}`,
+          pathname: `${props.path}${props.value}`,
         }}
       >
         {props.main}
@@ -117,6 +117,8 @@ export default function TablePages(props: {
   initSelect: string;
   selectLabel: string;
   mainLink: boolean;
+  linkValues: Map<string, string>;
+  path: string;
 }) {
   const classes = useStyles();
   const [initSelect, setYear] = React.useState(props.initSelect);
@@ -199,7 +201,12 @@ export default function TablePages(props: {
               return (
                 <TableRow hover tabIndex={-1} key={teamData.main}>
                   <TableCell component="th" id={labelId} scope="row" padding="none">
-                    <Main mainLink={props.mainLink} main={teamData.main} value={'test'} />
+                    <Main
+                      mainLink={props.mainLink}
+                      main={teamData.main}
+                      value={props.linkValues.get(teamData.main)}
+                      path={props.path}
+                    />
                   </TableCell>
                   {_.map(teamData, (val, key) => {
                     if (key === 'main') {

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -67,6 +67,7 @@ func GetBatting(playerID string, db *sql.DB) (battings []data.BATTERGRADES) {
 	return battings
 }
 
+// GetCareer 選手情報を取得する
 func GetCareer(playerID string, db *sql.DB) (career data.CAREER) {
 	rows, err := db.Query("SELECT * FROM players WHERE player_id = $1", playerID)
 
@@ -84,6 +85,7 @@ func GetCareer(playerID string, db *sql.DB) (career data.CAREER) {
 	return career
 }
 
+// GetPlayersByTeamIDAndYear チームIDと年から選手一覧を取得する
 func GetPlayersByTeamIDAndYear(teamID string, year string, db *sql.DB) (players []data.PLAYER) {
 	rows, err := db.Query("SELECT * FROM team_players WHERE year = $1 AND team_id = $2", year, teamID)
 

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -84,7 +84,7 @@ func GetCareer(playerID string, db *sql.DB) (career data.CAREER) {
 	return career
 }
 
-func GetPlayersByTeamIDandYear(teamID string, year string, db *sql.DB) (players []data.PLAYER) {
+func GetPlayersByTeamIDAndYear(teamID string, year string, db *sql.DB) (players []data.PLAYER) {
 	rows, err := db.Query("SELECT * FROM team_players WHERE year = $1 AND team_id = $2", year, teamID)
 
 	if err != nil {

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -14,6 +14,59 @@ import (
 	"github.com/tokuchi765/npb-analysis/team"
 )
 
+// GetPitching 個人投手成績一覧を取得する
+func GetPitching(playerID string, db *sql.DB) (pitchings []data.PICHERGRADES) {
+	rows, err := db.Query("SELECT * FROM picher_grades WHERE player_id = $1", playerID)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var playerID string
+		var pitching data.PICHERGRADES
+		rows.Scan(&playerID, &pitching.Year, &pitching.TeamID, &pitching.Team,
+			&pitching.Piched, &pitching.Win, &pitching.Lose, &pitching.Save,
+			&pitching.Hold, &pitching.HoldPoint, &pitching.CompleteGame, &pitching.Shutout,
+			&pitching.NoWalks, &pitching.WinningRate, &pitching.Batter, &pitching.InningsPitched,
+			&pitching.Hit, &pitching.HomeRun, &pitching.BaseOnBalls, &pitching.HitByPitches,
+			&pitching.StrikeOut, &pitching.WildPitches, &pitching.Balk, &pitching.RunsAllowed,
+			&pitching.EarnedRun, &pitching.EarnedRunAverage)
+
+		pitchings = append(pitchings, pitching)
+	}
+
+	return pitchings
+}
+
+// GetBatting 個人打撃成績一覧を取得する
+func GetBatting(playerID string, db *sql.DB) (battings []data.BATTERGRADES) {
+	rows, err := db.Query("SELECT * FROM batter_grades WHERE player_id = $1", playerID)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var playerID string
+		var batting data.BATTERGRADES
+		rows.Scan(&playerID, &batting.Year, &batting.TeamID, &batting.Team, &batting.Games,
+			&batting.PlateAppearance, &batting.AtBat, &batting.Score, &batting.Hit,
+			&batting.Double, &batting.Triple, &batting.HomeRun, &batting.BaseHit,
+			&batting.RunsBattedIn, &batting.StolenBase, &batting.CaughtStealing, &batting.SacrificeHits,
+			&batting.SacrificeFlies, &batting.BaseOnBalls, &batting.HitByPitches, &batting.StrikeOut,
+			&batting.GroundedIntoDoublePlay, &batting.BattingAverage, &batting.SluggingPercentage, &batting.OnBasePercentage)
+
+		battings = append(battings, batting)
+	}
+
+	return battings
+}
+
 func GetCareer(playerID string, db *sql.DB) (career data.CAREER) {
 	rows, err := db.Query("SELECT * FROM players WHERE player_id = $1", playerID)
 

--- a/main.go
+++ b/main.go
@@ -65,8 +65,6 @@ func main() {
 		setSystemSetting("created_add_value", "true", db)
 	}
 
-	defer db.Close()
-
 	// webサーバーを起動
 	router := setupRouter()
 	router.Run(":8081")

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func getCareers(c *gin.Context) {
 	teamID := c.Param("teamId")
 	year := c.Param("year")
 
-	players := grades.GetPlayersByTeamIDandYear(teamID, year, db)
+	players := grades.GetPlayersByTeamIDAndYear(teamID, year, db)
 	var careers []player.CAREER
 	for _, player := range players {
 		career := grades.GetCareer(player.PlayerID, db)

--- a/main.go
+++ b/main.go
@@ -126,11 +126,25 @@ func setupRouter() *gin.Engine {
 	// チームごとの選手情報一覧を取得
 	router.GET("/team/careers/:teamId/:year", getCareers)
 
+	// 選手情報取得
+	router.GET("/player/:playerId", getPlayer)
+
 	// 画面表示
 	router.Use(static.Serve("/", static.LocalFile("./frontend/build", true)))
 
 	return router
 
+}
+
+func getPlayer(c *gin.Context) {
+	db := getDB()
+	defer db.Close()
+	playerID := c.Param("playerId")
+	c.JSON(http.StatusOK, gin.H{
+		"career":   grades.GetCareer(playerID, db),
+		"batting":  grades.GetBatting(playerID, db),
+		"pitching": grades.GetPitching(playerID, db),
+	})
 }
 
 func getCareers(c *gin.Context) {


### PR DESCRIPTION
# 共通機能修正
- テーブルページの先頭カラムをリンクに変更できるように修正
![image](https://user-images.githubusercontent.com/55987154/109415403-d3143080-79fb-11eb-9cea-4676c35a0fd5.png)
- プルダウンの値が未設定の場合、表示しないように修正
![image](https://user-images.githubusercontent.com/55987154/109415431-0c4ca080-79fc-11eb-9913-0206e85e5505.png)

# 機能内容
- 個人成績ページを追加
  - 項目ごとにソート可能
![image](https://user-images.githubusercontent.com/55987154/109415576-cba15700-79fc-11eb-90ea-2aeeffd6dfd7.png)
![image](https://user-images.githubusercontent.com/55987154/109415642-33f03880-79fd-11eb-8fa3-e816dc76c972.png)