### PR TITLE
戻るボタンの追加

### DIFF
--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -113,8 +113,8 @@ function createBattingDataList(
 }
 
 const BattingPage: React.FC = () => {
+  const [initCentralYear, setCentralYear] = useState<string>('');
   const [centralBattingDatas, setCentralBattingData] = useState<BattingData[]>([]);
-  const [pacificBattingDatas, setPacificBattingData] = useState<BattingData[]>([]);
 
   const getBattingCentralDataList = async (year: string) => {
     const result = await axios.get(
@@ -135,8 +135,13 @@ const BattingPage: React.FC = () => {
 
     const battingData = createBattingDataList(teams);
 
+    setCentralYear(year);
+
     setCentralBattingData(battingData);
   };
+
+  const [initPacificYear, setPacificYear] = useState<string>('');
+  const [pacificBattingDatas, setPacificBattingData] = useState<BattingData[]>([]);
 
   const getBattingPacificDataList = async (year: string) => {
     const result = await axios.get(
@@ -157,6 +162,8 @@ const BattingPage: React.FC = () => {
 
     const battingData = createBattingDataList(pacificTeams);
 
+    setPacificYear(year);
+
     setPacificBattingData(battingData);
   };
 
@@ -171,12 +178,13 @@ const BattingPage: React.FC = () => {
     <GenericTemplate title="チーム打撃成績ページ">
       <TablePages
         title={'シーズン打撃成績(セ)'}
+        setSelect={setCentralYear}
         getDataList={getBattingCentralDataList}
         datas={centralBattingDatas}
         selects={years}
         headCells={headCells}
         initSorted={'battingAverage'}
-        initSelect={'2020'}
+        initSelect={initCentralYear}
         selectLabel={'年'}
         mainLink={false}
         linkValues={new Map<string, string>()}
@@ -184,12 +192,13 @@ const BattingPage: React.FC = () => {
       />
       <TablePages
         title={'シーズン打撃成績(パ)'}
+        setSelect={setPacificYear}
         getDataList={getBattingPacificDataList}
         datas={pacificBattingDatas}
         selects={years}
         headCells={headCells}
         initSorted={'battingAverage'}
-        initSelect={'2020'}
+        initSelect={initPacificYear}
         selectLabel={'年'}
         mainLink={false}
         linkValues={new Map<string, string>()}

--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -133,11 +133,8 @@ const BattingPage: React.FC = () => {
       return teanStatses;
     });
 
-    const battingData = createBattingDataList(teams);
-
     setCentralYear(year);
-
-    setCentralBattingData(battingData);
+    setCentralBattingData(createBattingDataList(teams));
   };
 
   const [initPacificYear, setPacificYear] = useState<string>('');
@@ -160,11 +157,8 @@ const BattingPage: React.FC = () => {
       return teamBattings;
     });
 
-    const battingData = createBattingDataList(pacificTeams);
-
     setPacificYear(year);
-
-    setPacificBattingData(battingData);
+    setPacificBattingData(createBattingDataList(pacificTeams));
   };
 
   useEffect(() => {

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -248,9 +248,7 @@ const HomePage: React.FC = () => {
         return teamBattings;
       });
 
-      const centralBattingAverage = createCentralBattingAverages(centralTeams);
-
-      setCentralData(centralBattingAverage);
+      setCentralData(createCentralBattingAverages(centralTeams));
 
       const pacificTeams = _.map(result.data.teamBatting, (teamBatting) => {
         const teamBattings = {
@@ -264,9 +262,7 @@ const HomePage: React.FC = () => {
         return teamBattings;
       });
 
-      const pacificBattingAverage = createPacificBattingAverages(pacificTeams);
-
-      setPacificData(pacificBattingAverage);
+      setPacificData(createPacificBattingAverages(pacificTeams));
     })();
   }, []);
 

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -108,8 +108,8 @@ function createPitchingDataList(
 }
 
 const PitchingPage: React.FC = () => {
+  const [initCentralYear, setCentralYear] = useState<string>('');
   const [centralDatas, setCentralData] = useState<PitchingData[]>([]);
-  const [pacificDatas, setPacificData] = useState<PitchingData[]>([]);
 
   const getCentralPitchingDataList = async (year: string) => {
     const result = await axios.get(
@@ -127,8 +127,13 @@ const PitchingPage: React.FC = () => {
       };
     });
 
+    setCentralYear(year);
+
     setCentralData(createPitchingDataList(centralPitchings));
   };
+
+  const [initPacificYear, setPacificYear] = useState<string>('');
+  const [pacificDatas, setPacificData] = useState<PitchingData[]>([]);
 
   const getPacificPitchingDataList = async (year: string) => {
     const result = await axios.get(
@@ -146,6 +151,8 @@ const PitchingPage: React.FC = () => {
       };
     });
 
+    setPacificYear(year);
+
     setPacificData(createPitchingDataList(pacificPitchings));
   };
 
@@ -160,12 +167,13 @@ const PitchingPage: React.FC = () => {
     <GenericTemplate title="チーム投手成績ページ">
       <TablePages
         title={'シーズン投手成績(セ)'}
+        setSelect={setCentralYear}
         getDataList={getCentralPitchingDataList}
         datas={centralDatas}
         selects={years}
         headCells={headCells}
         initSorted={'earnedRunAverage'}
-        initSelect={'2020'}
+        initSelect={initCentralYear}
         selectLabel={'年'}
         mainLink={false}
         linkValues={new Map<string, string>()}
@@ -173,12 +181,13 @@ const PitchingPage: React.FC = () => {
       />
       <TablePages
         title={'シーズン投手成績(パ)'}
+        setSelect={setPacificYear}
         getDataList={getPacificPitchingDataList}
         datas={pacificDatas}
         selects={years}
         headCells={headCells}
         initSorted={'earnedRunAverage'}
-        initSelect={'2020'}
+        initSelect={initPacificYear}
         selectLabel={'年'}
         mainLink={false}
         linkValues={new Map<string, string>()}

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import GenericTemplate from '../templates/GenericTemplate';
+import Button from '@material-ui/core/Button';
 import TablePages, { HeadCell } from './TablePages';
 import axios from 'axios';
 import _ from 'lodash';
@@ -141,6 +142,9 @@ const PlayerPage: React.FC<PageProps> = (props) => {
 
   return (
     <GenericTemplate title={playerName}>
+      <Button onClick={() => props.history.goBack()} variant="contained" color="primary">
+        戻る
+      </Button>
       <TablePages
         title={'打撃成績'}
         setSelect={function () {

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -143,6 +143,9 @@ const PlayerPage: React.FC<PageProps> = (props) => {
     <GenericTemplate title={playerName}>
       <TablePages
         title={'打撃成績'}
+        setSelect={function () {
+          return;
+        }}
         getDataList={getPlayerDatas}
         datas={battingDates}
         selects={[]}
@@ -156,6 +159,9 @@ const PlayerPage: React.FC<PageProps> = (props) => {
       />
       <TablePages
         title={'投手成績'}
+        setSelect={function () {
+          return;
+        }}
         getDataList={getPlayerDatas}
         datas={pitchingDates}
         selects={[]}

--- a/frontend/src/components/pages/SeasonPage.tsx
+++ b/frontend/src/components/pages/SeasonPage.tsx
@@ -94,11 +94,8 @@ const headCells: HeadCell[] = [
 ];
 
 const SeasonPage: React.FC = () => {
+  const [initCentralYear, setCentralYear] = useState<string>('');
   const [centralTeamDatas, setCentralTeamlData] = useState<
-    { main: string; winningRate: number; win: number; lose: number; draw: number }[]
-  >([]);
-
-  const [pacificTeamDatas, setPacificTeamlData] = useState<
     { main: string; winningRate: number; win: number; lose: number; draw: number }[]
   >([]);
 
@@ -121,8 +118,15 @@ const SeasonPage: React.FC = () => {
 
     const test = createTeamDataList(teams);
 
+    setCentralYear(year);
+
     setCentralTeamlData(test);
   };
+
+  const [initPacificYear, setPacificYear] = useState<string>('');
+  const [pacificTeamDatas, setPacificTeamlData] = useState<
+    { main: string; winningRate: number; win: number; lose: number; draw: number }[]
+  >([]);
 
   const getTeamPacificDataList = async (year: string) => {
     const result = await axios.get(
@@ -143,6 +147,8 @@ const SeasonPage: React.FC = () => {
 
     const test = createTeamDataList(teams);
 
+    setPacificYear(year);
+
     setPacificTeamlData(test);
   };
 
@@ -157,12 +163,13 @@ const SeasonPage: React.FC = () => {
     <GenericTemplate title="チーム成績ページ">
       <TablePages
         title={'シーズン成績(セ)'}
+        setSelect={setCentralYear}
         getDataList={getTeamCentralDataList}
         datas={centralTeamDatas}
         selects={years}
         headCells={headCells}
         initSorted={'winningRate'}
-        initSelect={'2020'}
+        initSelect={initCentralYear}
         selectLabel={'年'}
         mainLink={false}
         linkValues={new Map<string, string>()}
@@ -170,12 +177,13 @@ const SeasonPage: React.FC = () => {
       />
       <TablePages
         title={'シーズン成績(パ)'}
+        setSelect={setPacificYear}
         getDataList={getTeamPacificDataList}
         datas={pacificTeamDatas}
         selects={years}
         headCells={headCells}
         initSorted={'winningRate'}
-        initSelect={'2020'}
+        initSelect={initPacificYear}
         selectLabel={'年'}
         mainLink={false}
         linkValues={new Map<string, string>()}

--- a/frontend/src/components/pages/SeasonPage.tsx
+++ b/frontend/src/components/pages/SeasonPage.tsx
@@ -116,11 +116,8 @@ const SeasonPage: React.FC = () => {
       return teanStatses;
     });
 
-    const test = createTeamDataList(teams);
-
     setCentralYear(year);
-
-    setCentralTeamlData(test);
+    setCentralTeamlData(createTeamDataList(teams));
   };
 
   const [initPacificYear, setPacificYear] = useState<string>('');
@@ -145,11 +142,8 @@ const SeasonPage: React.FC = () => {
       return teanStatses;
     });
 
-    const test = createTeamDataList(teams);
-
     setPacificYear(year);
-
-    setPacificTeamlData(test);
+    setPacificTeamlData(createTeamDataList(teams));
   };
 
   useEffect(() => {

--- a/frontend/src/components/pages/TablePages.tsx
+++ b/frontend/src/components/pages/TablePages.tsx
@@ -149,6 +149,7 @@ function Selectable(props: {
 
 export default function TablePages(props: {
   title: string;
+  setSelect: (select: string) => void;
   getDataList: (year: string) => void;
   datas: { main: string }[];
   selects: string[];
@@ -161,11 +162,10 @@ export default function TablePages(props: {
   path: string;
 }) {
   const classes = useStyles();
-  const [initSelect, setYear] = React.useState(props.initSelect);
   const [order, setOrder] = React.useState<Order>('desc');
   const [orderBy, setOrderBy] = React.useState<string>(props.initSorted);
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setYear(event.target.value as string);
+    props.setSelect(event.target.value as string);
     props.getDataList(String(event.target.value));
   };
   const handleRequestSort = (event: React.MouseEvent<unknown>, property: string) => {
@@ -184,7 +184,7 @@ export default function TablePages(props: {
           <Grid container className={classes.grid}>
             <Grid key={1} item>
               <Paper className={classes.paper}>
-                {initSelect}
+                {props.initSelect}
                 {props.title}
               </Paper>
             </Grid>
@@ -192,7 +192,7 @@ export default function TablePages(props: {
               <Selectable
                 formControl={classes.formControl}
                 selectLabel={props.selectLabel}
-                initSelect={initSelect}
+                initSelect={props.initSelect}
                 selects={props.selects}
                 handleChange={handleChange}
               />


### PR DESCRIPTION
# リファクタリング
- テーブルページのセレクト要素をuseStateで再設定しないように修正
  - この修正によって、個人ページからブラウザバックしても、選択したプルダウンが保持された状態になる。
https://github.com/tokuchi765/npb-analysis/commit/19ed5e83e9724983dc5d43918cd89d23f0c8e4bb

# 機能内容
- 戻るボタンを追加
![image](https://user-images.githubusercontent.com/55987154/110330666-61725d00-8061-11eb-90c2-beb580db75c4.png)
↓戻るボタン押下後も選択チームが保持されている
![image](https://user-images.githubusercontent.com/55987154/110330720-76e78700-8061-11eb-9bd8-f8feaf1704a5.png)