### PR TITLE
加重出塁率を追加

### DIFF
--- a/ER.a5er
+++ b/ER.a5er
@@ -142,6 +142,7 @@ Field="打席","plate_appearance","@INT",,,"","",$FFFFFFFF,""
 Field="打数","at_bat","@INT",,,"","",$FFFFFFFF,""
 Field="得点","score","@INT",,,"","",$FFFFFFFF,""
 Field="安打","hit","@INT",,,"","",$FFFFFFFF,""
+Field="単打","single","@INT",,,"","",$FFFFFFFF,""
 Field="二塁打","double","@INT",,,"","",$FFFFFFFF,""
 Field="三塁打","triple","@INT",,,"","",$FFFFFFFF,""
 Field="本塁打","home_run","@INT",,,"","",$FFFFFFFF,""
@@ -158,11 +159,12 @@ Field="併殺打","grounded_into_double_play","@INT",,,"","",$FFFFFFFF,""
 Field="打率","batting_average","@FLOAT",,,"","",$FFFFFFFF,""
 Field="長打率","slugging_percentage","@FLOAT",,,"","",$FFFFFFFF,""
 Field="出塁率","on_base_percentage","@FLOAT",,,"","",$FFFFFFFF,""
+Field="加重出塁率","w_oba","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20201208210742
-Position="MAIN",550,650,275,638
+ModifiedDateTime=20210309225528
+Position="MAIN",550,650,275,705
 ZOrder=5
 
 [Relation]

--- a/docker/initdb/01_init.sql
+++ b/docker/initdb/01_init.sql
@@ -1,5 +1,5 @@
 -- Project Name : npm-scraping
--- Date/Time    : 2021/02/14 22:25:55
+-- Date/Time    : 2021/03/09 22:56:01
 -- Author       : hiroki
 -- RDBMS Type   : PostgreSQL
 -- Application  : A5:SQL Mk-2
@@ -155,6 +155,7 @@ create table BATTER_GRADES (
   , at_bat integer
   , score integer
   , hit integer
+  , single integer
   , double integer
   , triple integer
   , home_run integer
@@ -171,6 +172,7 @@ create table BATTER_GRADES (
   , batting_average real
   , slugging_percentage real
   , on_base_percentage real
+  , w_oba real
   , constraint BATTER_GRADES_PKC primary key (player_id,year,team_id)
 ) ;
 
@@ -332,6 +334,7 @@ comment on column BATTER_GRADES.plate_appearance is '打席';
 comment on column BATTER_GRADES.at_bat is '打数';
 comment on column BATTER_GRADES.score is '得点';
 comment on column BATTER_GRADES.hit is '安打';
+comment on column BATTER_GRADES.single is '単打';
 comment on column BATTER_GRADES.double is '二塁打';
 comment on column BATTER_GRADES.triple is '三塁打';
 comment on column BATTER_GRADES.home_run is '本塁打';
@@ -348,6 +351,7 @@ comment on column BATTER_GRADES.grounded_into_double_play is '併殺打';
 comment on column BATTER_GRADES.batting_average is '打率';
 comment on column BATTER_GRADES.slugging_percentage is '長打率';
 comment on column BATTER_GRADES.on_base_percentage is '出塁率';
+comment on column BATTER_GRADES.w_oba is '加重出塁率';
 
 comment on table Players is '選手テーブル';
 comment on column Players.player_id is '選手ID';

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -56,6 +56,7 @@ type BATTERGRADES struct {
 	BattingAverage         float64 // 打率
 	SluggingPercentage     float64 // 長打率
 	OnBasePercentage       float64 // 出塁率
+	Woba                   float64 // 加重出塁率
 }
 
 // CAREER 成績

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -39,6 +39,7 @@ type BATTERGRADES struct {
 	AtBat                  int     // 打数
 	Score                  int     // 得点
 	Hit                    int     // 安打
+	Single                 int     //単打
 	Double                 int     // 二塁打
 	Triple                 int     // 三塁打
 	HomeRun                int     // 本塁打

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -18,6 +18,7 @@ interface BattingDate {
   homeRun: number;
   strikeOut: number;
   groundedIntoDoublePlay: number;
+  woba: number;
 }
 
 const batterHeadCells: HeadCell[] = [
@@ -30,6 +31,7 @@ const batterHeadCells: HeadCell[] = [
   { id: 'homeRun', numeric: true, disablePadding: true, label: '本塁打' },
   { id: 'strikeOut', numeric: true, disablePadding: true, label: '三振' },
   { id: 'groundedIntoDoublePlay', numeric: true, disablePadding: true, label: '併殺打' },
+  { id: 'woba', numeric: true, disablePadding: true, label: '加重出塁率' },
 ];
 
 function createBattingDatas(
@@ -43,6 +45,7 @@ function createBattingDatas(
     HomeRun: string;
     StrikeOut: string;
     GroundedIntoDoublePlay: string;
+    Woba: string;
   }[]
 ) {
   const battings: BattingDate[] = [];
@@ -57,6 +60,7 @@ function createBattingDatas(
       homeRun: Number(batting.HomeRun),
       strikeOut: Number(batting.StrikeOut),
       groundedIntoDoublePlay: Number(batting.GroundedIntoDoublePlay),
+      woba: Number(batting.Woba),
     });
   });
   return battings;

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -310,7 +310,7 @@ func ExtractionBatterGrades(batterMap *map[string][]data.BATTERGRADES, teamID st
 
 // InsertBatterGrades 引数で受け取ったBATTERGRADESをDBに登録する
 func InsertBatterGrades(batterMap map[string][]data.BATTERGRADES, db *sql.DB) {
-	stmt, err := db.Prepare("INSERT INTO batter_grades(player_id, year, team_id, team, games, plate_appearance, at_bat, score, hit, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, hit_by_pitches, strike_out, grounded_into_double_play, batting_average, slugging_percentage, on_base_percentage) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)")
+	stmt, err := db.Prepare("INSERT INTO batter_grades(player_id, year, team_id, team, games, plate_appearance, at_bat, score, hit, single, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, hit_by_pitches, strike_out, grounded_into_double_play, batting_average, slugging_percentage, on_base_percentage) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)")
 	if err != nil {
 		log.Print(err)
 	}
@@ -318,12 +318,17 @@ func InsertBatterGrades(batterMap map[string][]data.BATTERGRADES, db *sql.DB) {
 
 	for key, value := range batterMap {
 		for _, batter := range value {
-			if _, err := stmt.Exec(key, batter.Year, batter.TeamID, batter.Team, batter.Games, batter.PlateAppearance, batter.AtBat, batter.Score, batter.Hit, batter.Double, batter.Triple, batter.HomeRun, batter.BaseHit, batter.RunsBattedIn, batter.StolenBase, batter.CaughtStealing, batter.SacrificeHits, batter.SacrificeFlies, batter.BaseOnBalls, batter.HitByPitches, batter.StrikeOut, batter.GroundedIntoDoublePlay, batter.BattingAverage, batter.SluggingPercentage, batter.OnBasePercentage); err != nil {
+			setSingle(&batter)
+			if _, err := stmt.Exec(key, batter.Year, batter.TeamID, batter.Team, batter.Games, batter.PlateAppearance, batter.AtBat, batter.Score, batter.Hit, batter.Single, batter.Double, batter.Triple, batter.HomeRun, batter.BaseHit, batter.RunsBattedIn, batter.StolenBase, batter.CaughtStealing, batter.SacrificeHits, batter.SacrificeFlies, batter.BaseOnBalls, batter.HitByPitches, batter.StrikeOut, batter.GroundedIntoDoublePlay, batter.BattingAverage, batter.SluggingPercentage, batter.OnBasePercentage); err != nil {
 				fmt.Println(key + ":" + batter.Year)
 				log.Print(err)
 			}
 		}
 	}
+}
+
+func setSingle(batterGrades *data.BATTERGRADES) {
+	batterGrades.Single = batterGrades.Hit - batterGrades.Double - batterGrades.Triple - batterGrades.HomeRun
 }
 
 func readGrades(path string) (picherGradesList []data.PICHERGRADES, batterGradesList []data.BATTERGRADES) {

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -195,7 +195,9 @@ func ExtractionCareers(careers *[]data.CAREER, db *sql.DB) {
 
 	for rows.Next() {
 		var selectCareer data.CAREER
-		rows.Scan(&selectCareer.PlayerID, &selectCareer.Name, &selectCareer.Position, &selectCareer.PitchingAndBatting, &selectCareer.Height, &selectCareer.Weight, &selectCareer.Birthday, &selectCareer.Draft, &selectCareer.Career)
+		rows.Scan(&selectCareer.PlayerID, &selectCareer.Name, &selectCareer.Position,
+			&selectCareer.PitchingAndBatting, &selectCareer.Height, &selectCareer.Weight,
+			&selectCareer.Birthday, &selectCareer.Draft, &selectCareer.Career)
 		for index, career := range *careers {
 			if career.PlayerID == selectCareer.PlayerID {
 				*careers = unset(*careers, index)
@@ -219,7 +221,9 @@ func InsertCareers(careers []data.CAREER, db *sql.DB) {
 	}
 	defer stmt.Close()
 	for _, career := range careers {
-		if _, err := stmt.Exec(career.PlayerID, career.Name, career.Position, career.PitchingAndBatting, career.Height, career.Weight, career.Birthday, career.Draft, career.Career); err != nil {
+		if _, err := stmt.Exec(career.PlayerID, career.Name, career.Position,
+			career.PitchingAndBatting, career.Height, career.Weight,
+			career.Birthday, career.Draft, career.Career); err != nil {
 			fmt.Println(career.PlayerID + ":" + career.Name)
 			log.Print(err)
 		}
@@ -319,7 +323,15 @@ func InsertBatterGrades(batterMap map[string][]data.BATTERGRADES, db *sql.DB) {
 	for key, value := range batterMap {
 		for _, batter := range value {
 			setSingle(&batter)
-			if _, err := stmt.Exec(key, batter.Year, batter.TeamID, batter.Team, batter.Games, batter.PlateAppearance, batter.AtBat, batter.Score, batter.Hit, batter.Single, batter.Double, batter.Triple, batter.HomeRun, batter.BaseHit, batter.RunsBattedIn, batter.StolenBase, batter.CaughtStealing, batter.SacrificeHits, batter.SacrificeFlies, batter.BaseOnBalls, batter.HitByPitches, batter.StrikeOut, batter.GroundedIntoDoublePlay, batter.BattingAverage, batter.SluggingPercentage, batter.OnBasePercentage); err != nil {
+			if _, err := stmt.Exec(key, batter.Year, batter.TeamID, batter.Team,
+				batter.Games, batter.PlateAppearance, batter.AtBat,
+				batter.Score, batter.Hit, batter.Single,
+				batter.Double, batter.Triple, batter.HomeRun,
+				batter.BaseHit, batter.RunsBattedIn, batter.StolenBase,
+				batter.CaughtStealing, batter.SacrificeHits, batter.SacrificeFlies,
+				batter.BaseOnBalls, batter.HitByPitches, batter.StrikeOut,
+				batter.GroundedIntoDoublePlay, batter.BattingAverage, batter.SluggingPercentage,
+				batter.OnBasePercentage); err != nil {
 				fmt.Println(key + ":" + batter.Year)
 				log.Print(err)
 			}

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -56,11 +56,12 @@ func GetBatting(playerID string, db *sql.DB) (battings []data.BATTERGRADES) {
 		var playerID string
 		var batting data.BATTERGRADES
 		rows.Scan(&playerID, &batting.Year, &batting.TeamID, &batting.Team, &batting.Games,
-			&batting.PlateAppearance, &batting.AtBat, &batting.Score, &batting.Hit,
+			&batting.PlateAppearance, &batting.AtBat, &batting.Score, &batting.Hit, &batting.Single,
 			&batting.Double, &batting.Triple, &batting.HomeRun, &batting.BaseHit,
 			&batting.RunsBattedIn, &batting.StolenBase, &batting.CaughtStealing, &batting.SacrificeHits,
 			&batting.SacrificeFlies, &batting.BaseOnBalls, &batting.HitByPitches, &batting.StrikeOut,
-			&batting.GroundedIntoDoublePlay, &batting.BattingAverage, &batting.SluggingPercentage, &batting.OnBasePercentage)
+			&batting.GroundedIntoDoublePlay, &batting.BattingAverage, &batting.SluggingPercentage, &batting.OnBasePercentage,
+			&batting.Woba)
 
 		battings = append(battings, batting)
 	}

--- a/grades/property/config.json
+++ b/grades/property/config.json
@@ -1,0 +1,7 @@
+{
+    "single": 0.9,
+    "baseOnBallsAndHitByPitches": 0.7,
+    "double": 1.3,
+    "triple": 1.6,
+    "homeRun": 2.0
+}


### PR DESCRIPTION
# 機能内容
- 野手成績テーブルに単打と加重出塁率を追加
- DB登録処理に単打と加重出塁率を追加
- 個人成績ページの打撃成績に加重出塁率の表示を追加
![image](https://user-images.githubusercontent.com/55987154/112713474-a7139e80-8f18-11eb-8d95-75bb3663e4b4.png)