### PR TITLE
投手成績ページに総失点を追加

### DIFF
--- a/frontend/src/components/common/TableComponent.tsx
+++ b/frontend/src/components/common/TableComponent.tsx
@@ -16,6 +16,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import _ from 'lodash';
+import { ClassNameMap } from '@material-ui/core/styles/withStyles';
 
 type Order = 'asc' | 'desc';
 
@@ -147,6 +148,116 @@ function Selectable(props: {
   }
 }
 
+function TableComponentTitleBar(props: {
+  classes: ClassNameMap<'formControl' | 'title' | 'table' | 'grid' | 'visuallyHidden' | 'paper'>;
+  initSelect: string;
+  title: string;
+  selectLabel: string;
+  selects: string[];
+  handleChange:
+    | ((
+        event: React.ChangeEvent<{
+          name?: string | undefined;
+          value: unknown;
+        }>,
+        child: React.ReactNode
+      ) => void)
+    | undefined;
+}) {
+  return (
+    <Typography className={props.classes.title} variant="h6" id="tableTitle" component="div">
+      <Grid container className={props.classes.grid}>
+        <Grid key={1} item>
+          <Paper className={props.classes.paper}>
+            {props.initSelect}
+            {props.title}
+          </Paper>
+        </Grid>
+        <Grid key={2} item>
+          <Selectable
+            formControl={props.classes.formControl}
+            selectLabel={props.selectLabel}
+            initSelect={props.initSelect}
+            selects={props.selects}
+            handleChange={props.handleChange}
+          />
+        </Grid>
+      </Grid>
+    </Typography>
+  );
+}
+
+function TableComponentHader(props: {
+  classes: ClassNameMap<'formControl' | 'title' | 'table' | 'grid' | 'visuallyHidden' | 'paper'>;
+  headCells: HeadCell[];
+  orderBy: string;
+  order: Order;
+  createSortHandler: (property: string) => (event: React.MouseEvent<unknown>) => void;
+}) {
+  return (
+    <TableHead>
+      <TableRow>
+        {props.headCells.map((headCell) => (
+          <TableCell
+            key={headCell.id}
+            align={headCell.numeric ? 'right' : 'left'}
+            padding={headCell.disablePadding ? 'none' : 'default'}
+            sortDirection={props.orderBy === headCell.id ? props.order : false}
+          >
+            <TableSortLabel
+              active={props.orderBy === headCell.id}
+              direction={props.orderBy === headCell.id ? props.order : 'asc'}
+              onClick={props.createSortHandler(headCell.id)}
+            >
+              {headCell.label}
+              {props.orderBy === headCell.id ? (
+                <span className={props.classes.visuallyHidden}>
+                  {props.order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                </span>
+              ) : null}
+            </TableSortLabel>
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+}
+
+function TableComponentBody(props: {
+  datas: { main: string }[];
+  order: Order;
+  orderBy: string;
+  mainLink: boolean;
+  linkValues: Map<string, string>;
+  path: string;
+}) {
+  return (
+    <TableBody>
+      {stableSort(props.datas, getComparator(props.order, props.orderBy)).map((teamData, index) => {
+        const labelId = `enhanced-table-checkbox-${index}`;
+        return (
+          <TableRow hover tabIndex={-1} key={teamData.main}>
+            <TableCell component="th" id={labelId} scope="row" padding="none">
+              <Main
+                mainLink={props.mainLink}
+                main={teamData.main}
+                value={props.linkValues.get(teamData.main)}
+                path={props.path}
+              />
+            </TableCell>
+            {_.map(teamData, (val, key) => {
+              if (key === 'main') {
+                return;
+              }
+              return <TableCell align="right">{val}</TableCell>;
+            })}
+          </TableRow>
+        );
+      })}
+    </TableBody>
+  );
+}
+
 export function TableComponent(props: {
   title: string;
   setSelect: (select: string) => void;
@@ -180,74 +291,30 @@ export function TableComponent(props: {
   return (
     <React.Fragment>
       <TableContainer component={Paper}>
-        <Typography className={classes.title} variant="h6" id="tableTitle" component="div">
-          <Grid container className={classes.grid}>
-            <Grid key={1} item>
-              <Paper className={classes.paper}>
-                {props.initSelect}
-                {props.title}
-              </Paper>
-            </Grid>
-            <Grid key={2} item>
-              <Selectable
-                formControl={classes.formControl}
-                selectLabel={props.selectLabel}
-                initSelect={props.initSelect}
-                selects={props.selects}
-                handleChange={handleChange}
-              />
-            </Grid>
-          </Grid>
-        </Typography>
+        <TableComponentTitleBar
+          classes={classes}
+          initSelect={props.initSelect}
+          title={props.title}
+          selectLabel={props.selectLabel}
+          selects={props.selects}
+          handleChange={handleChange}
+        />
         <Table className={classes.table} aria-label="simple table">
-          <TableHead>
-            <TableRow>
-              {props.headCells.map((headCell) => (
-                <TableCell
-                  key={headCell.id}
-                  align={headCell.numeric ? 'right' : 'left'}
-                  padding={headCell.disablePadding ? 'none' : 'default'}
-                  sortDirection={orderBy === headCell.id ? order : false}
-                >
-                  <TableSortLabel
-                    active={orderBy === headCell.id}
-                    direction={orderBy === headCell.id ? order : 'asc'}
-                    onClick={createSortHandler(headCell.id)}
-                  >
-                    {headCell.label}
-                    {orderBy === headCell.id ? (
-                      <span className={classes.visuallyHidden}>
-                        {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
-                      </span>
-                    ) : null}
-                  </TableSortLabel>
-                </TableCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {stableSort(props.datas, getComparator(order, orderBy)).map((teamData, index) => {
-              const labelId = `enhanced-table-checkbox-${index}`;
-              return (
-                <TableRow hover tabIndex={-1} key={teamData.main}>
-                  <TableCell component="th" id={labelId} scope="row" padding="none">
-                    <Main
-                      mainLink={props.mainLink}
-                      main={teamData.main}
-                      value={props.linkValues.get(teamData.main)}
-                      path={props.path}
-                    />
-                  </TableCell>
-                  {_.map(teamData, (val, key) => {
-                    if (key === 'main') {
-                      return;
-                    }
-                    return <TableCell align="right">{val}</TableCell>;
-                  })}
-                </TableRow>
-              );
-            })}
-          </TableBody>
+          <TableComponentHader
+            classes={classes}
+            headCells={props.headCells}
+            orderBy={orderBy}
+            order={order}
+            createSortHandler={createSortHandler}
+          />
+          <TableComponentBody
+            datas={props.datas}
+            order={order}
+            orderBy={orderBy}
+            mainLink={props.mainLink}
+            linkValues={props.linkValues}
+            path={props.path}
+          />
         </Table>
       </TableContainer>
     </React.Fragment>

--- a/frontend/src/components/common/TableComponent.tsx
+++ b/frontend/src/components/common/TableComponent.tsx
@@ -147,7 +147,7 @@ function Selectable(props: {
   }
 }
 
-export default function TableComponent(props: {
+export function TableComponent(props: {
   title: string;
   setSelect: (select: string) => void;
   getDataList: (year: string) => void;

--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -180,9 +180,6 @@ const BattingPage: React.FC = () => {
         initSorted={'battingAverage'}
         initSelect={initCentralYear}
         selectLabel={'年'}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
       <TableComponent
         title={'シーズン打撃成績(パ)'}
@@ -194,9 +191,6 @@ const BattingPage: React.FC = () => {
         initSorted={'battingAverage'}
         initSelect={initPacificYear}
         selectLabel={'年'}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import GenericTemplate from '../templates/GenericTemplate';
-import TablePages, { HeadCell } from '../common/TableComponent';
+import { TableComponent, HeadCell } from '../common/TableComponent';
 import axios from 'axios';
 import _ from 'lodash';
 
@@ -170,7 +170,7 @@ const BattingPage: React.FC = () => {
 
   return (
     <GenericTemplate title="チーム打撃成績ページ">
-      <TablePages
+      <TableComponent
         title={'シーズン打撃成績(セ)'}
         setSelect={setCentralYear}
         getDataList={getBattingCentralDataList}
@@ -184,7 +184,7 @@ const BattingPage: React.FC = () => {
         linkValues={new Map<string, string>()}
         path={''}
       />
-      <TablePages
+      <TableComponent
         title={'シーズン打撃成績(パ)'}
         setSelect={setPacificYear}
         getDataList={getBattingPacificDataList}

--- a/frontend/src/components/pages/ManagerPage.tsx
+++ b/frontend/src/components/pages/ManagerPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import GenericTemplate from '../templates/GenericTemplate';
 import axios from 'axios';
 import _ from 'lodash';
-import TablePages, { HeadCell } from '../common/TableComponent';
+import { TableComponent, HeadCell } from '../common/TableComponent';
 
 const THREE = '(3年以上)';
 const ALL = '(全て)';
@@ -129,7 +129,7 @@ const ManagerPage: React.FC = () => {
 
   return (
     <GenericTemplate title="監督ページ">
-      <TablePages
+      <TableComponent
         title={'ピタゴラス勝率'}
         setSelect={setSelect}
         getDataList={getTeamDataList}

--- a/frontend/src/components/pages/ManagerPage.tsx
+++ b/frontend/src/components/pages/ManagerPage.tsx
@@ -139,9 +139,6 @@ const ManagerPage: React.FC = () => {
         initSorted={'winningRateDifferenceAverage'}
         initSelect={initSelect}
         selectLabel={'選択'}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -27,6 +27,7 @@ interface PitchingData {
   main: string;
   earnedRunAverage: number;
   games: number;
+  runsAllowed: number;
   save: number;
   hold: number;
   homeRun: number;
@@ -38,6 +39,7 @@ const headCells: HeadCell[] = [
   { id: 'main', numeric: false, disablePadding: true, label: 'チーム名' },
   { id: 'earnedRunAverage', numeric: true, disablePadding: false, label: '防御率' },
   { id: 'games', numeric: true, disablePadding: false, label: '試合' },
+  { id: 'runsAllowed', numeric: true, disablePadding: false, label: '失点' },
   { id: 'save', numeric: true, disablePadding: false, label: 'セーブ' },
   { id: 'hold', numeric: true, disablePadding: false, label: 'ホールド' },
   { id: 'homeRun', numeric: true, disablePadding: false, label: '被本塁打' },
@@ -49,6 +51,7 @@ function createPitchingData(
   main: string,
   earnedRunAverage: number,
   games: number,
+  runsAllowed: number,
   save: number,
   hold: number,
   homeRun: number,
@@ -59,6 +62,7 @@ function createPitchingData(
     main,
     earnedRunAverage,
     games,
+    runsAllowed,
     save,
     hold,
     homeRun,
@@ -95,6 +99,7 @@ function createPitchingDataList(
           key,
           val.EarnedRunAverage,
           val.Games,
+          val.RunsAllowed,
           val.Save,
           val.Hold,
           val.HomeRun,

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import GenericTemplate from '../templates/GenericTemplate';
-import TablePages, { HeadCell } from '../common/TableComponent';
+import { TableComponent, HeadCell } from '../common/TableComponent';
 import axios from 'axios';
 import _ from 'lodash';
 
@@ -170,7 +170,7 @@ const PitchingPage: React.FC = () => {
 
   return (
     <GenericTemplate title="チーム投手成績ページ">
-      <TablePages
+      <TableComponent
         title={'シーズン投手成績(セ)'}
         setSelect={setCentralYear}
         getDataList={getCentralPitchingDataList}
@@ -184,7 +184,7 @@ const PitchingPage: React.FC = () => {
         linkValues={new Map<string, string>()}
         path={''}
       />
-      <TablePages
+      <TableComponent
         title={'シーズン投手成績(パ)'}
         setSelect={setPacificYear}
         getDataList={getPacificPitchingDataList}

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -180,9 +180,6 @@ const PitchingPage: React.FC = () => {
         initSorted={'earnedRunAverage'}
         initSelect={initCentralYear}
         selectLabel={'年'}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
       <TableComponent
         title={'シーズン投手成績(パ)'}
@@ -194,9 +191,6 @@ const PitchingPage: React.FC = () => {
         initSorted={'earnedRunAverage'}
         initSelect={initPacificYear}
         selectLabel={'年'}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import GenericTemplate from '../templates/GenericTemplate';
 import Button from '@material-ui/core/Button';
-import TablePages, { HeadCell } from '../common/TableComponent';
+import { TableComponent, HeadCell } from '../common/TableComponent';
 import axios from 'axios';
 import _ from 'lodash';
 
@@ -149,7 +149,7 @@ const PlayerPage: React.FC<PageProps> = (props) => {
       <Button onClick={() => props.history.goBack()} variant="contained" color="primary">
         戻る
       </Button>
-      <TablePages
+      <TableComponent
         title={'打撃成績'}
         setSelect={function () {
           return;
@@ -165,7 +165,7 @@ const PlayerPage: React.FC<PageProps> = (props) => {
         linkValues={new Map<string, string>()}
         path={''}
       />
-      <TablePages
+      <TableComponent
         title={'投手成績'}
         setSelect={function () {
           return;

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -161,9 +161,6 @@ const PlayerPage: React.FC<PageProps> = (props) => {
         initSorted={'main'}
         initSelect={''}
         selectLabel={''}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
       <TableComponent
         title={'投手成績'}
@@ -177,9 +174,6 @@ const PlayerPage: React.FC<PageProps> = (props) => {
         initSorted={'main'}
         initSelect={''}
         selectLabel={''}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
     </GenericTemplate>
   );

--- a/frontend/src/components/pages/PlayersPage.tsx
+++ b/frontend/src/components/pages/PlayersPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
 import GenericTemplate from '../templates/GenericTemplate';
-import { TableComponent, HeadCell } from '../common/TableComponent';
+import { TableLinkComponent, HeadCell } from '../common/TableComponent';
 import axios from 'axios';
 import _ from 'lodash';
 import * as H from 'history';
@@ -127,7 +127,7 @@ const PlayersPage: React.FC<PageProps> = (props) => {
 
   return (
     <GenericTemplate title="選手一覧ページ">
-      <TableComponent
+      <TableLinkComponent
         title={'選手一覧'}
         setSelect={setInitTeam}
         getDataList={getPlayerList}

--- a/frontend/src/components/pages/PlayersPage.tsx
+++ b/frontend/src/components/pages/PlayersPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
 import GenericTemplate from '../templates/GenericTemplate';
-import TablePages, { HeadCell } from '../common/TableComponent';
+import { TableComponent, HeadCell } from '../common/TableComponent';
 import axios from 'axios';
 import _ from 'lodash';
 import * as H from 'history';
@@ -127,7 +127,7 @@ const PlayersPage: React.FC<PageProps> = (props) => {
 
   return (
     <GenericTemplate title="選手一覧ページ">
-      <TablePages
+      <TableComponent
         title={'選手一覧'}
         setSelect={setInitTeam}
         getDataList={getPlayerList}

--- a/frontend/src/components/pages/SeasonPage.tsx
+++ b/frontend/src/components/pages/SeasonPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import GenericTemplate from '../templates/GenericTemplate';
 import axios from 'axios';
 import _ from 'lodash';
-import TablePages, { HeadCell } from '../common/TableComponent';
+import { TableComponent, HeadCell } from '../common/TableComponent';
 
 const years = [
   '2005',
@@ -155,7 +155,7 @@ const SeasonPage: React.FC = () => {
 
   return (
     <GenericTemplate title="チーム成績ページ">
-      <TablePages
+      <TableComponent
         title={'シーズン成績(セ)'}
         setSelect={setCentralYear}
         getDataList={getTeamCentralDataList}
@@ -169,7 +169,7 @@ const SeasonPage: React.FC = () => {
         linkValues={new Map<string, string>()}
         path={''}
       />
-      <TablePages
+      <TableComponent
         title={'シーズン成績(パ)'}
         setSelect={setPacificYear}
         getDataList={getTeamPacificDataList}

--- a/frontend/src/components/pages/SeasonPage.tsx
+++ b/frontend/src/components/pages/SeasonPage.tsx
@@ -165,9 +165,6 @@ const SeasonPage: React.FC = () => {
         initSorted={'winningRate'}
         initSelect={initCentralYear}
         selectLabel={'年'}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
       <TableComponent
         title={'シーズン成績(パ)'}
@@ -179,9 +176,6 @@ const SeasonPage: React.FC = () => {
         initSorted={'winningRate'}
         initSelect={initPacificYear}
         selectLabel={'年'}
-        mainLink={false}
-        linkValues={new Map<string, string>()}
-        path={''}
       />
     </GenericTemplate>
   );


### PR DESCRIPTION
# 機能追加
- 投手成績ページに失点を追加
![image](https://user-images.githubusercontent.com/55987154/114403388-b57fdc80-9bdf-11eb-9fea-99f246b35982.png)

# リファクタリング
- テーブルをリンク用のコンポーネントと通常のコンポーネントに分割
  - TableComponent
  - TableLinkComponent