### PR TITLE
BABIPを追加

### DIFF
--- a/ER.a5er
+++ b/ER.a5er
@@ -1,7 +1,7 @@
-﻿# A5:ER FORMAT:15
+﻿# A5:ER FORMAT:16
 # A5:ER ENCODING:UTF8
 # A5:ER Mk-1 Copyright © 2007 m.matsubara
-# A5:SQL Mk-2 Version 2.16.2 Copyright © 1997 - 2021 m.matsubara
+# A5:SQL Mk-2 Version 2.17.1 Copyright © 1997 - 2022 m.matsubara
 #  https://a5m2.mmatsubara.com
 
 [Manager]
@@ -37,6 +37,7 @@ SqlSeparator=0
 UpperCaseKeyword=0
 ShowTag=1
 ShowCommonAttributes=0
+BugFixEntityWidth=0
 
 [Entity]
 PName=PICHER_GRADES
@@ -72,11 +73,12 @@ Field="ボーク","balk","@FLOAT",,,"","",$FFFFFFFF,""
 Field="失点","runs_allowed","@FLOAT",,,"","",$FFFFFFFF,""
 Field="自責点","earned_run","@FLOAT",,,"","",$FFFFFFFF,""
 Field="防御率","earned_run_average","@FLOAT",,,"","",$FFFFFFFF,""
+Field="被BABIP","babip","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20201208210812
-Position="MAIN",1050,650,299,672
+ModifiedDateTime=20220326155946
+Position="MAIN",1050,650,299,698
 ZOrder=1
 
 [Entity]
@@ -161,11 +163,12 @@ Field="長打率","slugging_percentage","@FLOAT",,,"","",$FFFFFFFF,""
 Field="出塁率","on_base_percentage","@FLOAT",,,"","",$FFFFFFFF,""
 Field="加重出塁率","w_oba","@FLOAT",,,"","",$FFFFFFFF,""
 Field="創出得点","rc","@FLOAT",,,"","",$FFFFFFFF,""
+Field="BABIP","babip","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20220101234605
-Position="MAIN",550,650,275,728
+ModifiedDateTime=20220326183734
+Position="MAIN",550,650,275,749
 ZOrder=5
 
 [Relation]
@@ -278,11 +281,12 @@ Field="三振","strike_out","@INT",,,"","",$FFFFFFFF,""
 Field="併殺打","grounded_into_double_play","@INT",,,"","",$FFFFFFFF,""
 Field="長打率","slugging_percentage","@FLOAT",,,"","",$FFFFFFFF,""
 Field="出塁率","on_base_percentage","@FLOAT",,,"","",$FFFFFFFF,""
+Field="BABIP","babip","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20210328165407
-Position="MAIN",1500,500,298,622
+ModifiedDateTime=20220326183751
+Position="MAIN",1500,500,298,646
 ZOrder=16
 
 [Relation]
@@ -340,11 +344,12 @@ Field="暴投","wild_pitches","@INT",,,"","",$FFFFFFFF,""
 Field="ボーク","balk","@INT",,,"","",$FFFFFFFF,""
 Field="失点","runs_allowed","@INT",,,"","",$FFFFFFFF,""
 Field="自責点","earned_run","@INT",,,"","",$FFFFFFFF,""
+Field="被BABIP","babip","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20201123215355
-Position="MAIN",1900,500,302,653
+ModifiedDateTime=20220326183446
+Position="MAIN",1900,500,302,672
 ZOrder=18
 
 [Relation]

--- a/docker/initdb/01_init.sql
+++ b/docker/initdb/01_init.sql
@@ -1,5 +1,5 @@
 -- Project Name : npm-scraping
--- Date/Time    : 2022/01/01 23:47:06
+-- Date/Time    : 2022/03/26 18:39:10
 -- Author       : hiroki
 -- RDBMS Type   : PostgreSQL
 -- Application  : A5:SQL Mk-2
@@ -96,6 +96,7 @@ create table TEAM_PITCHING (
   , balk integer
   , runs_allowed integer
   , earned_run integer
+  , babip real
   , constraint TEAM_PITCHING_PKC primary key (team_id,year)
 ) ;
 
@@ -126,6 +127,7 @@ create table TEAM_BATTING (
   , grounded_into_double_play integer
   , slugging_percentage real
   , on_base_percentage real
+  , babip real
   , constraint TEAM_BATTING_PKC primary key (team_id,year)
 ) ;
 
@@ -177,6 +179,7 @@ create table BATTER_GRADES (
   , on_base_percentage real
   , w_oba real
   , rc real
+  , babip real
   , constraint BATTER_GRADES_PKC primary key (player_id,year,team_id)
 ) ;
 
@@ -224,6 +227,7 @@ create table PICHER_GRADES (
   , runs_allowed real
   , earned_run real
   , earned_run_average real
+  , babip real
   , constraint PICHER_GRADES_PKC primary key (player_id,year,team_id)
 ) ;
 
@@ -293,6 +297,7 @@ comment on column TEAM_PITCHING.wild_pitches is '暴投';
 comment on column TEAM_PITCHING.balk is 'ボーク';
 comment on column TEAM_PITCHING.runs_allowed is '失点';
 comment on column TEAM_PITCHING.earned_run is '自責点';
+comment on column TEAM_PITCHING.babip is '被BABIP';
 
 comment on table TEAM_BATTING is 'チーム打撃成績';
 comment on column TEAM_BATTING.team_id is 'チームID';
@@ -319,6 +324,7 @@ comment on column TEAM_BATTING.strike_out is '三振';
 comment on column TEAM_BATTING.grounded_into_double_play is '併殺打';
 comment on column TEAM_BATTING.slugging_percentage is '長打率';
 comment on column TEAM_BATTING.on_base_percentage is '出塁率';
+comment on column TEAM_BATTING.babip is 'BABIP';
 
 comment on table TEAM_NAME is 'チーム名';
 comment on column TEAM_NAME.team_name_id is 'チーム名ID';
@@ -358,6 +364,7 @@ comment on column BATTER_GRADES.slugging_percentage is '長打率';
 comment on column BATTER_GRADES.on_base_percentage is '出塁率';
 comment on column BATTER_GRADES.w_oba is '加重出塁率';
 comment on column BATTER_GRADES.rc is '創出得点';
+comment on column BATTER_GRADES.babip is 'BABIP';
 
 comment on table Players is '選手テーブル';
 comment on column Players.player_id is '選手ID';
@@ -397,3 +404,4 @@ comment on column PICHER_GRADES.balk is 'ボーク';
 comment on column PICHER_GRADES.runs_allowed is '失点';
 comment on column PICHER_GRADES.earned_run is '自責点';
 comment on column PICHER_GRADES.earned_run_average is '防御率';
+comment on column PICHER_GRADES.babip is '被BABIP';

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -27,6 +27,7 @@ type PICHERGRADES struct {
 	RunsAllowed      float64 // 失点
 	EarnedRun        float64 // 自責点
 	EarnedRunAverage float64 // 防御率
+	BABIP            float64 // 被BABIP
 }
 
 // BATTERGRADES 成績
@@ -58,6 +59,7 @@ type BATTERGRADES struct {
 	OnBasePercentage       float64 // 出塁率
 	Woba                   float64 // 加重出塁率
 	RC                     float64 // 創出得点
+	BABIP                  float64 // BABIP
 }
 
 // SetRC RCを算出して設定する

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -30,6 +30,11 @@ type PICHERGRADES struct {
 	BABIP            float64 // 被BABIP
 }
 
+// SetBABIP 被BABIPを算出して設定する
+func (picherGrades *PICHERGRADES) SetBABIP() {
+	picherGrades.BABIP = (float64(picherGrades.Hit) - float64(picherGrades.HomeRun)) / (float64(picherGrades.Batter) - (float64(picherGrades.BaseOnBalls) + float64(picherGrades.HitByPitches)) - float64(picherGrades.StrikeOut) - float64(picherGrades.HomeRun))
+}
+
 // BATTERGRADES 成績
 type BATTERGRADES struct {
 	Year                   string  // 年度
@@ -68,6 +73,11 @@ func (batterGrades *BATTERGRADES) SetRC() {
 	B := float64(batterGrades.BaseHit) + (0.26 * float64(batterGrades.BaseOnBalls+batterGrades.HitByPitches)) + (0.53 * float64(batterGrades.SacrificeHits+batterGrades.SacrificeFlies)) + (0.64 * float64(batterGrades.StolenBase)) - (0.03 * float64(batterGrades.StrikeOut))
 	C := float64(batterGrades.AtBat + batterGrades.BaseOnBalls + batterGrades.HitByPitches + batterGrades.SacrificeFlies + batterGrades.SacrificeHits)
 	batterGrades.RC = ((A + (2.4 * C)) * (B + (3 * C)) / (9 * C)) - (0.9 * C)
+}
+
+// SetBABIP BABIPを算出して設定する
+func (batterGrades *BATTERGRADES) SetBABIP() {
+	batterGrades.BABIP = (float64(batterGrades.Hit) - float64(batterGrades.HomeRun)) / (float64(batterGrades.AtBat) - float64(batterGrades.StrikeOut) - float64(batterGrades.HomeRun) + float64(batterGrades.SacrificeFlies))
 }
 
 // CAREER 成績

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -1,5 +1,7 @@
 package player
 
+import "math"
+
 // PICHERGRADES 成績
 type PICHERGRADES struct {
 	Year             string  // 年度
@@ -33,6 +35,9 @@ type PICHERGRADES struct {
 // SetBABIP 被BABIPを算出して設定する
 func (picherGrades *PICHERGRADES) SetBABIP() {
 	picherGrades.BABIP = (float64(picherGrades.Hit) - float64(picherGrades.HomeRun)) / (float64(picherGrades.Batter) - (float64(picherGrades.BaseOnBalls) + float64(picherGrades.HitByPitches)) - float64(picherGrades.StrikeOut) - float64(picherGrades.HomeRun))
+	if math.IsNaN(picherGrades.BABIP) {
+		picherGrades.BABIP = 0.0
+	}
 }
 
 // BATTERGRADES 成績
@@ -73,11 +78,17 @@ func (batterGrades *BATTERGRADES) SetRC() {
 	B := float64(batterGrades.BaseHit) + (0.26 * float64(batterGrades.BaseOnBalls+batterGrades.HitByPitches)) + (0.53 * float64(batterGrades.SacrificeHits+batterGrades.SacrificeFlies)) + (0.64 * float64(batterGrades.StolenBase)) - (0.03 * float64(batterGrades.StrikeOut))
 	C := float64(batterGrades.AtBat + batterGrades.BaseOnBalls + batterGrades.HitByPitches + batterGrades.SacrificeFlies + batterGrades.SacrificeHits)
 	batterGrades.RC = ((A + (2.4 * C)) * (B + (3 * C)) / (9 * C)) - (0.9 * C)
+	if math.IsNaN(batterGrades.RC) {
+		batterGrades.RC = 0.0
+	}
 }
 
 // SetBABIP BABIPを算出して設定する
 func (batterGrades *BATTERGRADES) SetBABIP() {
 	batterGrades.BABIP = (float64(batterGrades.Hit) - float64(batterGrades.HomeRun)) / (float64(batterGrades.AtBat) - float64(batterGrades.StrikeOut) - float64(batterGrades.HomeRun) + float64(batterGrades.SacrificeFlies))
+	if math.IsNaN(batterGrades.BABIP) {
+		batterGrades.BABIP = 0.0
+	}
 }
 
 // CAREER 成績

--- a/entity/player/player_test.go
+++ b/entity/player/player_test.go
@@ -53,3 +53,56 @@ func TestBATTERGRADES_SetRC(t *testing.T) {
 		})
 	}
 }
+
+func TestBATTERGRADES_SetBABIP(t *testing.T) {
+	tests := []struct {
+		name         string
+		batterGrades *BATTERGRADES
+		wantBABIP    float64
+	}{
+		{
+			"BABIP算出",
+			&BATTERGRADES{
+				AtBat:          500,
+				Hit:            240,
+				HomeRun:        20,
+				StrikeOut:      50,
+				SacrificeFlies: 10,
+			},
+			0.5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.batterGrades.SetBABIP()
+			assert.Equal(t, tt.wantBABIP, tt.batterGrades.BABIP)
+		})
+	}
+}
+
+func TestPICHERGRADES_SetBABIP(t *testing.T) {
+	tests := []struct {
+		name         string
+		picherGrades *PICHERGRADES
+		wantBABIP    float64
+	}{
+		{
+			"被BABIP算出",
+			&PICHERGRADES{
+				Batter:       500,
+				Hit:          240,
+				HomeRun:      20,
+				StrikeOut:    20,
+				BaseOnBalls:  10,
+				HitByPitches: 10,
+			},
+			0.5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.picherGrades.SetBABIP()
+			assert.Equal(t, tt.wantBABIP, tt.picherGrades.BABIP)
+		})
+	}
+}

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -42,6 +42,11 @@ type TeamBatting struct {
 	BABIP                  float64 // BABIP
 }
 
+// SetBABIP BABIPを算出して設定する
+func (teamBatting *TeamBatting) SetBABIP() {
+	teamBatting.BABIP = (float64(teamBatting.Hit) - float64(teamBatting.HomeRun)) / (float64(teamBatting.AtBat) - float64(teamBatting.StrikeOut) - float64(teamBatting.HomeRun) + float64(teamBatting.SacrificeFlies))
+}
+
 // TeamPitching チーム投手成績
 type TeamPitching struct {
 	TeamID           string  // チームID
@@ -70,6 +75,11 @@ type TeamPitching struct {
 	RunsAllowed      int     // 失点
 	EarnedRun        int     // 自責点
 	BABIP            float64 // 被BABIP
+}
+
+// SetBABIP 被BABIPを算出して設定する
+func (teamPitching *TeamPitching) SetBABIP() {
+	teamPitching.BABIP = (float64(teamPitching.Hit) - float64(teamPitching.HomeRun)) / (float64(teamPitching.Batter) - (float64(teamPitching.BaseOnBalls) + float64(teamPitching.HitByPitches)) - float64(teamPitching.StrikeOut) - float64(teamPitching.HomeRun))
 }
 
 // TeamLeagueStats チームシーズン成績

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -1,5 +1,7 @@
 package team
 
+import "math"
+
 // TEAMDATA チーム情報
 type TEAMDATA struct {
 	TeamID     string // チームID
@@ -45,6 +47,9 @@ type TeamBatting struct {
 // SetBABIP BABIPを算出して設定する
 func (teamBatting *TeamBatting) SetBABIP() {
 	teamBatting.BABIP = (float64(teamBatting.Hit) - float64(teamBatting.HomeRun)) / (float64(teamBatting.AtBat) - float64(teamBatting.StrikeOut) - float64(teamBatting.HomeRun) + float64(teamBatting.SacrificeFlies))
+	if math.IsNaN(teamBatting.BABIP) {
+		teamBatting.BABIP = 0.0
+	}
 }
 
 // TeamPitching チーム投手成績
@@ -80,6 +85,9 @@ type TeamPitching struct {
 // SetBABIP 被BABIPを算出して設定する
 func (teamPitching *TeamPitching) SetBABIP() {
 	teamPitching.BABIP = (float64(teamPitching.Hit) - float64(teamPitching.HomeRun)) / (float64(teamPitching.Batter) - (float64(teamPitching.BaseOnBalls) + float64(teamPitching.HitByPitches)) - float64(teamPitching.StrikeOut) - float64(teamPitching.HomeRun))
+	if math.IsNaN(teamPitching.BABIP) {
+		teamPitching.BABIP = 0.0
+	}
 }
 
 // TeamLeagueStats チームシーズン成績

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -39,6 +39,7 @@ type TeamBatting struct {
 	GroundedIntoDoublePlay int     // 併殺打
 	SluggingPercentage     float64 // 長打率
 	OnBasePercentage       float64 // 出塁率
+	BABIP                  float64 // BABIP
 }
 
 // TeamPitching チーム投手成績
@@ -68,6 +69,7 @@ type TeamPitching struct {
 	Balk             int     // ボーク
 	RunsAllowed      int     // 失点
 	EarnedRun        int     // 自責点
+	BABIP            float64 // 被BABIP
 }
 
 // TeamLeagueStats チームシーズン成績

--- a/entity/team/team_test.go
+++ b/entity/team/team_test.go
@@ -1,0 +1,60 @@
+package team
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeamBatting_SetBABIP(t *testing.T) {
+	tests := []struct {
+		name        string
+		teamBatting *TeamBatting
+		wantBABIP   float64
+	}{
+		{
+			"BABIP算出",
+			&TeamBatting{
+				AtBat:          500,
+				Hit:            240,
+				HomeRun:        20,
+				StrikeOut:      50,
+				SacrificeFlies: 10,
+			},
+			0.5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.teamBatting.SetBABIP()
+			assert.Equal(t, tt.wantBABIP, tt.teamBatting.BABIP)
+		})
+	}
+}
+
+func TestTeamPitching_SetBABIP(t *testing.T) {
+	tests := []struct {
+		name         string
+		teamPitching *TeamPitching
+		wantBABIP    float64
+	}{
+		{
+			"被BABIP算出",
+			&TeamPitching{
+				Batter:       500,
+				Hit:          240,
+				HomeRun:      20,
+				StrikeOut:    20,
+				BaseOnBalls:  10,
+				HitByPitches: 10,
+			},
+			0.5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.teamPitching.SetBABIP()
+			assert.Equal(t, tt.wantBABIP, tt.teamPitching.BABIP)
+		})
+	}
+}

--- a/frontend/src/__test__/components/pages/__snapshots__/BattingPage.test.tsx.snap
+++ b/frontend/src/__test__/components/pages/__snapshots__/BattingPage.test.tsx.snap
@@ -822,6 +822,42 @@ exports[`打撃成績ページテスト スナップショット作成 1`] = `
                   </svg>
                 </span>
               </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  BABIP
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
             </tr>
           </thead>
           <tbody
@@ -1241,6 +1277,42 @@ exports[`打撃成績ページテスト スナップショット作成 1`] = `
                   tabIndex={0}
                 >
                   出塁率
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  BABIP
                   <svg
                     aria-hidden={true}
                     className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"

--- a/frontend/src/__test__/components/pages/__snapshots__/PitchingPage.test.tsx.snap
+++ b/frontend/src/__test__/components/pages/__snapshots__/PitchingPage.test.tsx.snap
@@ -822,6 +822,42 @@ exports[`投手成績ページテスト スナップショット作成 1`] = `
                   </svg>
                 </span>
               </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  被BABIP
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
             </tr>
           </thead>
           <tbody
@@ -1241,6 +1277,42 @@ exports[`投手成績ページテスト スナップショット作成 1`] = `
                   tabIndex={0}
                 >
                   三振
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  被BABIP
                   <svg
                     aria-hidden={true}
                     className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"

--- a/frontend/src/__test__/components/pages/__snapshots__/PlayerPage.test.tsx.snap
+++ b/frontend/src/__test__/components/pages/__snapshots__/PlayerPage.test.tsx.snap
@@ -861,6 +861,42 @@ exports[`選手詳細ページテスト スナップショット作成 1`] = `
                   </svg>
                 </span>
               </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-paddingNone"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  BABIP
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
             </tr>
           </thead>
           <tbody
@@ -1259,6 +1295,42 @@ exports[`選手詳細ページテスト スナップショット作成 1`] = `
                   tabIndex={0}
                 >
                   死球
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-paddingNone"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  被BABIP
                   <svg
                     aria-hidden={true}
                     className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"

--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -14,6 +14,7 @@ interface BattingData {
   baseOnBalls: number;
   strikeOut: number;
   onBasePercentage: number;
+  babip: number;
 }
 
 const headCells: HeadCell[] = [
@@ -26,6 +27,7 @@ const headCells: HeadCell[] = [
   { id: 'baseOnBalls', numeric: true, disablePadding: false, label: '四球' },
   { id: 'strikeOut', numeric: true, disablePadding: false, label: '三振' },
   { id: 'onBasePercentage', numeric: true, disablePadding: false, label: '出塁率' },
+  { id: 'babip', numeric: true, disablePadding: false, label: 'BABIP' },
 ];
 
 function createBattingData(
@@ -37,7 +39,8 @@ function createBattingData(
   homeRun: number,
   baseOnBalls: number,
   strikeOut: number,
-  onBasePercentage: number
+  onBasePercentage: number,
+  babip: number
 ) {
   const result: BattingData = {
     main,
@@ -49,6 +52,7 @@ function createBattingData(
     baseOnBalls,
     strikeOut,
     onBasePercentage,
+    babip,
   };
   return result;
 }
@@ -85,7 +89,8 @@ function createBattingDataList(
           val.HomeRun,
           val.BaseOnBalls,
           val.StrikeOut,
-          val.OnBasePercentage
+          val.OnBasePercentage,
+          val.BABIP
         )
       );
     });

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -14,6 +14,7 @@ interface PitchingData {
   homeRun: number;
   baseOnBalls: number;
   strikeOut: number;
+  babip: number;
 }
 
 const headCells: HeadCell[] = [
@@ -26,6 +27,7 @@ const headCells: HeadCell[] = [
   { id: 'homeRun', numeric: true, disablePadding: false, label: '被本塁打' },
   { id: 'baseOnBalls', numeric: true, disablePadding: false, label: '与四球' },
   { id: 'strikeOut', numeric: true, disablePadding: false, label: '三振' },
+  { id: 'babip', numeric: true, disablePadding: false, label: '被BABIP' },
 ];
 
 function createPitchingData(
@@ -37,7 +39,8 @@ function createPitchingData(
   hold: number,
   homeRun: number,
   baseOnBalls: number,
-  strikeOut: number
+  strikeOut: number,
+  babip: number
 ) {
   const result: PitchingData = {
     main,
@@ -49,6 +52,7 @@ function createPitchingData(
     homeRun,
     baseOnBalls,
     strikeOut,
+    babip,
   };
   return result;
 }
@@ -85,7 +89,8 @@ function createPitchingDataList(
           val.Hold,
           val.HomeRun,
           val.BaseOnBalls,
-          val.StrikeOut
+          val.StrikeOut,
+          val.BABIP
         )
       );
     });

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -20,6 +20,7 @@ interface BattingDate {
   groundedIntoDoublePlay: number;
   woba: number;
   rc: number;
+  babip: number;
 }
 
 const batterHeadCells: HeadCell[] = [
@@ -34,6 +35,7 @@ const batterHeadCells: HeadCell[] = [
   { id: 'groundedIntoDoublePlay', numeric: true, disablePadding: true, label: '併殺打' },
   { id: 'woba', numeric: true, disablePadding: true, label: '加重出塁率' },
   { id: 'rc', numeric: true, disablePadding: true, label: '創出得点' },
+  { id: 'babip', numeric: true, disablePadding: true, label: 'BABIP' },
 ];
 
 function createBattingDatas(
@@ -49,6 +51,7 @@ function createBattingDatas(
     GroundedIntoDoublePlay: string;
     Woba: string;
     RC: string;
+    BABIP: string;
   }[]
 ) {
   const battings: BattingDate[] = [];
@@ -65,6 +68,7 @@ function createBattingDatas(
       groundedIntoDoublePlay: Number(batting.GroundedIntoDoublePlay),
       woba: Number(batting.Woba),
       rc: Number(batting.RC),
+      babip: Number(batting.BABIP),
     });
   });
   return battings;
@@ -81,6 +85,7 @@ interface PitchingDate {
   homeRun: number;
   baseOnBalls: number;
   hitByPitches: number;
+  babip: number;
 }
 
 const pitcherHeadCells: HeadCell[] = [
@@ -94,6 +99,7 @@ const pitcherHeadCells: HeadCell[] = [
   { id: 'homeRun', numeric: true, disablePadding: true, label: '被本塁打' },
   { id: 'baseOnBalls', numeric: true, disablePadding: true, label: '四球' },
   { id: 'hitByPitches', numeric: true, disablePadding: true, label: '死球' },
+  { id: 'babip', numeric: true, disablePadding: true, label: '被BABIP' },
 ];
 
 function createPitchingDatas(
@@ -108,6 +114,7 @@ function createPitchingDatas(
     HomeRun: string;
     BaseOnBalls: string;
     HitByPitches: string;
+    BABIP: string;
   }[]
 ) {
   const pitchings: PitchingDate[] = [];
@@ -123,6 +130,7 @@ function createPitchingDatas(
       homeRun: Number(pitching.HomeRun),
       baseOnBalls: Number(pitching.BaseOnBalls),
       hitByPitches: Number(pitching.HitByPitches),
+      babip: Number(pitching.BABIP),
     });
   });
   return pitchings;

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -3,6 +3,7 @@ package grades
 import (
 	"encoding/json"
 	"log"
+	"math"
 	"os"
 	"strings"
 
@@ -143,6 +144,9 @@ func setWoba(batterGrades *data.BATTERGRADES, config *config) {
 		config.HomeRun*float64(batterGrades.HomeRun)
 	denominator := (float64(batterGrades.AtBat) + float64(batterGrades.BaseOnBalls) + float64(batterGrades.HitByPitches) + float64(batterGrades.SacrificeFlies))
 	batterGrades.Woba = molecule / denominator
+	if math.IsNaN(batterGrades.Woba) {
+		batterGrades.Woba = 0.0
+	}
 }
 
 type config struct {

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -108,6 +108,7 @@ func (Interactor *GradesInteractor) ExtractionPicherGrades(picherMap *map[string
 func (Interactor *GradesInteractor) InsertPicherGrades(picherMap map[string][]data.PICHERGRADES) {
 	for key, pichers := range picherMap {
 		for _, picher := range pichers {
+			picher.SetBABIP()
 			Interactor.GradesRepository.InsertPicherGrades(key, picher)
 		}
 	}
@@ -128,6 +129,7 @@ func (Interactor *GradesInteractor) InsertBatterGrades(batterMap map[string][]da
 			setSingle(&batter)
 			setWoba(&batter, config)
 			batter.SetRC()
+			batter.SetBABIP()
 			Interactor.GradesRepository.InsertBatterGrades(key, batter)
 		}
 	}

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -104,9 +104,13 @@ func (Interactor *GradesInteractor) ExtractionPicherGrades(picherMap *map[string
 	Interactor.GradesRepository.ExtractionPicherGrades(picherMap, teamID)
 }
 
-// InsertPicherGrades 引数で受け取ったPICHERGRADESリストから重複選手を除外する
+// InsertPicherGrades 引数で受け取ったPICHERGRADESをDBに登録する
 func (Interactor *GradesInteractor) InsertPicherGrades(picherMap map[string][]data.PICHERGRADES) {
-	Interactor.GradesRepository.InsertPicherGrades(picherMap)
+	for key, pichers := range picherMap {
+		for _, picher := range pichers {
+			Interactor.GradesRepository.InsertPicherGrades(key, picher)
+		}
+	}
 }
 
 // ExtractionBatterGrades 引数で受け取ったBATTERGRADESリストから重複選手を除外する

--- a/infrastructure/grades_repository.go
+++ b/infrastructure/grades_repository.go
@@ -33,7 +33,7 @@ func (Repository *GradesRepository) GetPitchings(playerID string) (pitchings []d
 			&pitching.NoWalks, &pitching.WinningRate, &pitching.Batter, &pitching.InningsPitched,
 			&pitching.Hit, &pitching.HomeRun, &pitching.BaseOnBalls, &pitching.HitByPitches,
 			&pitching.StrikeOut, &pitching.WildPitches, &pitching.Balk, &pitching.RunsAllowed,
-			&pitching.EarnedRun, &pitching.EarnedRunAverage)
+			&pitching.EarnedRun, &pitching.EarnedRunAverage, &pitching.BABIP)
 
 		pitchings = append(pitchings, pitching)
 	}
@@ -60,7 +60,7 @@ func (Repository *GradesRepository) GetBattings(playerID string) (battings []dat
 			&batting.RunsBattedIn, &batting.StolenBase, &batting.CaughtStealing, &batting.SacrificeHits,
 			&batting.SacrificeFlies, &batting.BaseOnBalls, &batting.HitByPitches, &batting.StrikeOut,
 			&batting.GroundedIntoDoublePlay, &batting.BattingAverage, &batting.SluggingPercentage, &batting.OnBasePercentage,
-			&batting.Woba, &batting.RC)
+			&batting.Woba, &batting.RC, &batting.BABIP)
 
 		battings = append(battings, batting)
 	}

--- a/infrastructure/grades_repository.go
+++ b/infrastructure/grades_repository.go
@@ -195,20 +195,16 @@ func (Repository *GradesRepository) ExtractionPicherGrades(picherMap *map[string
 }
 
 // InsertPicherGrades 引数で受け取ったPICHERGRADESリストから重複選手を除外する
-func (Repository *GradesRepository) InsertPicherGrades(picherMap map[string][]data.PICHERGRADES) {
+func (Repository *GradesRepository) InsertPicherGrades(key string, picher data.PICHERGRADES) {
 	stmt, err := Repository.Conn.Prepare("INSERT INTO picher_grades(player_id, year, team_id, team, piched, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run, earned_run_average) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
 
-	for key, value := range picherMap {
-		for _, picher := range value {
-			if _, err := stmt.Exec(key, picher.Year, picher.TeamID, picher.Team, picher.Piched, picher.Win, picher.Lose, picher.Save, picher.Hold, picher.HoldPoint, picher.CompleteGame, picher.Shutout, picher.NoWalks, picher.WinningRate, picher.Batter, picher.InningsPitched, picher.Hit, picher.HomeRun, picher.BaseOnBalls, picher.HitByPitches, picher.StrikeOut, picher.WildPitches, picher.Balk, picher.RunsAllowed, picher.EarnedRun, picher.EarnedRunAverage); err != nil {
-				fmt.Println(key + ":" + picher.Year)
-				log.Print(err)
-			}
-		}
+	if _, err := stmt.Exec(key, picher.Year, picher.TeamID, picher.Team, picher.Piched, picher.Win, picher.Lose, picher.Save, picher.Hold, picher.HoldPoint, picher.CompleteGame, picher.Shutout, picher.NoWalks, picher.WinningRate, picher.Batter, picher.InningsPitched, picher.Hit, picher.HomeRun, picher.BaseOnBalls, picher.HitByPitches, picher.StrikeOut, picher.WildPitches, picher.Balk, picher.RunsAllowed, picher.EarnedRun, picher.EarnedRunAverage); err != nil {
+		fmt.Println(key + ":" + picher.Year)
+		log.Print(err)
 	}
 }
 

--- a/infrastructure/grades_repository.go
+++ b/infrastructure/grades_repository.go
@@ -196,13 +196,13 @@ func (Repository *GradesRepository) ExtractionPicherGrades(picherMap *map[string
 
 // InsertPicherGrades 引数で受け取ったPICHERGRADESリストから重複選手を除外する
 func (Repository *GradesRepository) InsertPicherGrades(key string, picher data.PICHERGRADES) {
-	stmt, err := Repository.Conn.Prepare("INSERT INTO picher_grades(player_id, year, team_id, team, piched, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run, earned_run_average) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)")
+	stmt, err := Repository.Conn.Prepare("INSERT INTO picher_grades(player_id, year, team_id, team, piched, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run,  earned_run_average, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
 
-	if _, err := stmt.Exec(key, picher.Year, picher.TeamID, picher.Team, picher.Piched, picher.Win, picher.Lose, picher.Save, picher.Hold, picher.HoldPoint, picher.CompleteGame, picher.Shutout, picher.NoWalks, picher.WinningRate, picher.Batter, picher.InningsPitched, picher.Hit, picher.HomeRun, picher.BaseOnBalls, picher.HitByPitches, picher.StrikeOut, picher.WildPitches, picher.Balk, picher.RunsAllowed, picher.EarnedRun, picher.EarnedRunAverage); err != nil {
+	if _, err := stmt.Exec(key, picher.Year, picher.TeamID, picher.Team, picher.Piched, picher.Win, picher.Lose, picher.Save, picher.Hold, picher.HoldPoint, picher.CompleteGame, picher.Shutout, picher.NoWalks, picher.WinningRate, picher.Batter, picher.InningsPitched, picher.Hit, picher.HomeRun, picher.BaseOnBalls, picher.HitByPitches, picher.StrikeOut, picher.WildPitches, picher.Balk, picher.RunsAllowed, picher.EarnedRun, picher.EarnedRunAverage, picher.BABIP); err != nil {
 		fmt.Println(key + ":" + picher.Year)
 		log.Print(err)
 	}
@@ -232,14 +232,14 @@ func (Repository *GradesRepository) ExtractionBatterGrades(batterMap *map[string
 
 // InsertBatterGrades 引数で受け取ったBATTERGRADESをDBに登録する
 func (Repository *GradesRepository) InsertBatterGrades(playerID string, batterGrades data.BATTERGRADES) {
-	stmt, err := Repository.Conn.Prepare("INSERT INTO batter_grades(player_id, year, team_id, team, games, plate_appearance, at_bat, score, hit, single, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, hit_by_pitches, strike_out, grounded_into_double_play, batting_average, slugging_percentage, on_base_percentage, w_oba, rc) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28)")
+	stmt, err := Repository.Conn.Prepare("INSERT INTO batter_grades(player_id, year, team_id, team, games, plate_appearance, at_bat, score, hit, single, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, hit_by_pitches, strike_out, grounded_into_double_play, batting_average, slugging_percentage, on_base_percentage, w_oba, rc, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
 
 	// 加重出塁率の計算に必要なconfigファイルを読み込む
-	if _, err := stmt.Exec(playerID, batterGrades.Year, batterGrades.TeamID, batterGrades.Team, batterGrades.Games, batterGrades.PlateAppearance, batterGrades.AtBat, batterGrades.Score, batterGrades.Hit, batterGrades.Single, batterGrades.Double, batterGrades.Triple, batterGrades.HomeRun, batterGrades.BaseHit, batterGrades.RunsBattedIn, batterGrades.StolenBase, batterGrades.CaughtStealing, batterGrades.SacrificeHits, batterGrades.SacrificeFlies, batterGrades.BaseOnBalls, batterGrades.HitByPitches, batterGrades.StrikeOut, batterGrades.GroundedIntoDoublePlay, batterGrades.BattingAverage, batterGrades.SluggingPercentage, batterGrades.OnBasePercentage, batterGrades.Woba, batterGrades.RC); err != nil {
+	if _, err := stmt.Exec(playerID, batterGrades.Year, batterGrades.TeamID, batterGrades.Team, batterGrades.Games, batterGrades.PlateAppearance, batterGrades.AtBat, batterGrades.Score, batterGrades.Hit, batterGrades.Single, batterGrades.Double, batterGrades.Triple, batterGrades.HomeRun, batterGrades.BaseHit, batterGrades.RunsBattedIn, batterGrades.StolenBase, batterGrades.CaughtStealing, batterGrades.SacrificeHits, batterGrades.SacrificeFlies, batterGrades.BaseOnBalls, batterGrades.HitByPitches, batterGrades.StrikeOut, batterGrades.GroundedIntoDoublePlay, batterGrades.BattingAverage, batterGrades.SluggingPercentage, batterGrades.OnBasePercentage, batterGrades.Woba, batterGrades.RC, batterGrades.BABIP); err != nil {
 		fmt.Println(playerID + ":" + batterGrades.Year)
 		log.Print(err)
 	}

--- a/infrastructure/grades_repository_test.go
+++ b/infrastructure/grades_repository_test.go
@@ -22,7 +22,7 @@ func TestGradesRepository_InsertPicherGrades_GetPitchings(t *testing.T) {
 			"投手成績登録と取得",
 			args{
 				"53355134",
-				createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89),
+				createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3),
 			},
 		},
 	}
@@ -43,11 +43,11 @@ func TestGradesRepository_InsertPicherGrades_GetPitchings(t *testing.T) {
 
 func createPicherGradesList() []data.PICHERGRADES {
 	return []data.PICHERGRADES{
-		createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89),
+		createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3),
 	}
 }
 
-func createPicherGrades(year string, teamID string, team string, piched float64, win float64, lose float64, save float64, hold float64, holdPoint float64, completeGame float64, shutout float64, noWalks float64, winningRate float64, batter float64, inningsPitched float64, hit float64, homeRun float64, baseOnBalls float64, hitByPitches float64, strikeOut float64, wildPitches float64, balk float64, runsAllowed float64, earnedRun float64, earnedRunAverage float64) data.PICHERGRADES {
+func createPicherGrades(year string, teamID string, team string, piched float64, win float64, lose float64, save float64, hold float64, holdPoint float64, completeGame float64, shutout float64, noWalks float64, winningRate float64, batter float64, inningsPitched float64, hit float64, homeRun float64, baseOnBalls float64, hitByPitches float64, strikeOut float64, wildPitches float64, balk float64, runsAllowed float64, earnedRun float64, earnedRunAverage float64, babip float64) data.PICHERGRADES {
 	return data.PICHERGRADES{
 		Year:             year,
 		TeamID:           teamID,
@@ -74,6 +74,7 @@ func createPicherGrades(year string, teamID string, team string, piched float64,
 		RunsAllowed:      runsAllowed,
 		EarnedRun:        earnedRun,
 		EarnedRunAverage: earnedRunAverage,
+		BABIP:            babip,
 	}
 }
 
@@ -90,7 +91,7 @@ func TestGradesRepository_InsertBatterGrades_GetBattings(t *testing.T) {
 			"打者成績登録と取得",
 			args{
 				"01605136",
-				createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2),
+				createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3),
 			},
 		},
 	}
@@ -111,11 +112,11 @@ func TestGradesRepository_InsertBatterGrades_GetBattings(t *testing.T) {
 
 func createBatterGradesList() []data.BATTERGRADES {
 	return []data.BATTERGRADES{
-		createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2),
+		createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3),
 	}
 }
 
-func createBatterGrades(Year string, TeamID string, Team string, Games int, PlateAppearance int, AtBat int, Score int, Hit int, Single int, Double int, Triple int, HomeRun int, BaseHit int, RunsBattedIn int, StolenBase int, CaughtStealing int, SacrificeHits int, SacrificeFlies int, BaseOnBalls int, HitByPitches int, StrikeOut int, GroundedIntoDoublePlay int, BattingAverage float64, SluggingPercentage float64, OnBasePercentage float64, Woba float64, RC float64) data.BATTERGRADES {
+func createBatterGrades(Year string, TeamID string, Team string, Games int, PlateAppearance int, AtBat int, Score int, Hit int, Single int, Double int, Triple int, HomeRun int, BaseHit int, RunsBattedIn int, StolenBase int, CaughtStealing int, SacrificeHits int, SacrificeFlies int, BaseOnBalls int, HitByPitches int, StrikeOut int, GroundedIntoDoublePlay int, BattingAverage float64, SluggingPercentage float64, OnBasePercentage float64, Woba float64, RC float64, BABIP float64) data.BATTERGRADES {
 	return data.BATTERGRADES{
 		Year:                   Year,
 		TeamID:                 TeamID,
@@ -144,6 +145,7 @@ func createBatterGrades(Year string, TeamID string, Team string, Games int, Plat
 		OnBasePercentage:       OnBasePercentage,
 		Woba:                   Woba,
 		RC:                     RC,
+		BABIP:                  BABIP,
 	}
 }
 
@@ -315,7 +317,7 @@ func TestGradesRepository_ExtractionPicherGrades(t *testing.T) {
 			sqlHandler := new(SQLHandler)
 			sqlHandler.Conn = db
 			repository := GradesRepository{SQLHandler: *sqlHandler}
-			repository.InsertPicherGrades("53355134", createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89))
+			repository.InsertPicherGrades("53355134", createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3))
 			repository.ExtractionPicherGrades(&tt.args.picherMap, tt.args.teamID)
 			assert.Empty(t, tt.args.picherMap)
 		})
@@ -323,7 +325,7 @@ func TestGradesRepository_ExtractionPicherGrades(t *testing.T) {
 }
 
 func TestGradesRepository_ExtractionBatterGrades(t *testing.T) {
-	batter := createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2)
+	batter := createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3)
 	prayerID := "01605136"
 	type args struct {
 		prayerID string

--- a/infrastructure/grades_repository_test.go
+++ b/infrastructure/grades_repository_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestGradesRepository_InsertPicherGrades_GetPitchings(t *testing.T) {
 	type args struct {
-		playerID    string
-		pitchingMap map[string][]data.PICHERGRADES
+		playerID string
+		pitcher  data.PICHERGRADES
 	}
 	tests := []struct {
 		name string
@@ -22,7 +22,7 @@ func TestGradesRepository_InsertPicherGrades_GetPitchings(t *testing.T) {
 			"投手成績登録と取得",
 			args{
 				"53355134",
-				map[string][]data.PICHERGRADES{"53355134": createPicherGradesList()},
+				createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89),
 			},
 		},
 	}
@@ -34,9 +34,9 @@ func TestGradesRepository_InsertPicherGrades_GetPitchings(t *testing.T) {
 			sqlHandler := new(SQLHandler)
 			sqlHandler.Conn = db
 			repository := GradesRepository{SQLHandler: *sqlHandler}
-			repository.InsertPicherGrades(tt.args.pitchingMap)
+			repository.InsertPicherGrades(tt.args.playerID, tt.args.pitcher)
 			actual := repository.GetPitchings(tt.args.playerID)
-			assert.ElementsMatch(t, tt.args.pitchingMap["53355134"], actual)
+			assert.ElementsMatch(t, []data.PICHERGRADES{tt.args.pitcher}, actual)
 		})
 	}
 }
@@ -315,7 +315,7 @@ func TestGradesRepository_ExtractionPicherGrades(t *testing.T) {
 			sqlHandler := new(SQLHandler)
 			sqlHandler.Conn = db
 			repository := GradesRepository{SQLHandler: *sqlHandler}
-			repository.InsertPicherGrades(tt.args.picherMap)
+			repository.InsertPicherGrades("53355134", createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89))
 			repository.ExtractionPicherGrades(&tt.args.picherMap, tt.args.teamID)
 			assert.Empty(t, tt.args.picherMap)
 		})

--- a/infrastructure/team_repository.go
+++ b/infrastructure/team_repository.go
@@ -51,7 +51,7 @@ func (Repository *TeamRepository) GetTeamPitchings(years []int) (teamPitchingMap
 				&teamPitching.WinningRate, &teamPitching.Batter, &teamPitching.InningsPitched,
 				&teamPitching.Hit, &teamPitching.HomeRun, &teamPitching.BaseOnBalls,
 				&teamPitching.IntentionalWalk, &teamPitching.HitByPitches, &teamPitching.StrikeOut,
-				&teamPitching.WildPitches, &teamPitching.Balk, &teamPitching.RunsAllowed, &teamPitching.EarnedRun)
+				&teamPitching.WildPitches, &teamPitching.Balk, &teamPitching.RunsAllowed, &teamPitching.EarnedRun, &teamPitching.BABIP)
 			teamPitchings = append(teamPitchings, teamPitching)
 		}
 		teamPitchingMap[strYear] = teamPitchings
@@ -93,7 +93,7 @@ func (Repository *TeamRepository) GetTeamBattings(years []int) (teamBattingMap m
 				&teamBatting.AtBat, &teamBatting.Score, &teamBatting.Hit, &teamBatting.Double, &teamBatting.Triple, &teamBatting.HomeRun,
 				&teamBatting.BaseHit, &teamBatting.RunsBattedIn, &teamBatting.StolenBase, &teamBatting.CaughtStealing, &teamBatting.SacrificeHits,
 				&teamBatting.SacrificeFlies, &teamBatting.BaseOnBalls, &teamBatting.IntentionalWalk, &teamBatting.HitByPitches, &teamBatting.StrikeOut,
-				&teamBatting.GroundedIntoDoublePlay, &teamBatting.SluggingPercentage, &teamBatting.OnBasePercentage,
+				&teamBatting.GroundedIntoDoublePlay, &teamBatting.SluggingPercentage, &teamBatting.OnBasePercentage, &teamBatting.BABIP,
 			)
 			teamBattins = append(teamBattins, teamBatting)
 		}

--- a/infrastructure/team_repository.go
+++ b/infrastructure/team_repository.go
@@ -14,17 +14,15 @@ type TeamRepository struct {
 }
 
 // InsertTeamPitchings チーム投手成績をDBに登録する
-func (Repository *TeamRepository) InsertTeamPitchings(teamPitching []teamData.TeamPitching) {
+func (Repository *TeamRepository) InsertTeamPitchings(pitching teamData.TeamPitching) {
 	stmt, err := Repository.Conn.Prepare("INSERT INTO team_pitching(team_id, year, earned_run_average, games, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, intentional_walk, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
-	for _, pitching := range teamPitching {
-		if _, err := stmt.Exec(pitching.TeamID, pitching.Year, pitching.EarnedRunAverage, pitching.Games, pitching.Win, pitching.Lose, pitching.Save, pitching.Hold, pitching.HoldPoint, pitching.CompleteGame, pitching.Shutout, pitching.NoWalks, pitching.WinningRate, pitching.Batter, pitching.InningsPitched, pitching.Hit, pitching.HomeRun, pitching.BaseOnBalls, pitching.IntentionalWalk, pitching.HitByPitches, pitching.StrikeOut, pitching.WildPitches, pitching.Balk, pitching.RunsAllowed, pitching.EarnedRun); err != nil {
-			fmt.Println(pitching.TeamID + ":" + pitching.Year)
-			log.Print(err)
-		}
+	if _, err := stmt.Exec(pitching.TeamID, pitching.Year, pitching.EarnedRunAverage, pitching.Games, pitching.Win, pitching.Lose, pitching.Save, pitching.Hold, pitching.HoldPoint, pitching.CompleteGame, pitching.Shutout, pitching.NoWalks, pitching.WinningRate, pitching.Batter, pitching.InningsPitched, pitching.Hit, pitching.HomeRun, pitching.BaseOnBalls, pitching.IntentionalWalk, pitching.HitByPitches, pitching.StrikeOut, pitching.WildPitches, pitching.Balk, pitching.RunsAllowed, pitching.EarnedRun); err != nil {
+		fmt.Println(pitching.TeamID + ":" + pitching.Year)
+		log.Print(err)
 	}
 }
 
@@ -60,17 +58,15 @@ func (Repository *TeamRepository) GetTeamPitchings(years []int) (teamPitchingMap
 }
 
 // InsertTeamBattings チーム打撃成績をDBに登録する
-func (Repository *TeamRepository) InsertTeamBattings(teamBatting []teamData.TeamBatting) {
+func (Repository *TeamRepository) InsertTeamBattings(batting teamData.TeamBatting) {
 	stmt, err := Repository.Conn.Prepare("INSERT INTO team_batting(team_id, year, batting_average, games, plate_appearance, at_bat, score, hit, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, intentional_walk, hit_by_pitches, strike_out, grounded_into_double_play, slugging_percentage, on_base_percentage) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
-	for _, batting := range teamBatting {
-		if _, err := stmt.Exec(batting.TeamID, batting.Year, batting.BattingAverage, batting.Games, batting.PlateAppearance, batting.AtBat, batting.Score, batting.Hit, batting.Double, batting.Triple, batting.HomeRun, batting.BaseHit, batting.RunsBattedIn, batting.StolenBase, batting.CaughtStealing, batting.SacrificeHits, batting.SacrificeFlies, batting.BaseOnBalls, batting.IntentionalWalk, batting.HitByPitches, batting.StrikeOut, batting.GroundedIntoDoublePlay, batting.SluggingPercentage, batting.OnBasePercentage); err != nil {
-			fmt.Println(batting.TeamID + ":" + batting.Year)
-			log.Print(err)
-		}
+	if _, err := stmt.Exec(batting.TeamID, batting.Year, batting.BattingAverage, batting.Games, batting.PlateAppearance, batting.AtBat, batting.Score, batting.Hit, batting.Double, batting.Triple, batting.HomeRun, batting.BaseHit, batting.RunsBattedIn, batting.StolenBase, batting.CaughtStealing, batting.SacrificeHits, batting.SacrificeFlies, batting.BaseOnBalls, batting.IntentionalWalk, batting.HitByPitches, batting.StrikeOut, batting.GroundedIntoDoublePlay, batting.SluggingPercentage, batting.OnBasePercentage); err != nil {
+		fmt.Println(batting.TeamID + ":" + batting.Year)
+		log.Print(err)
 	}
 }
 

--- a/infrastructure/team_repository.go
+++ b/infrastructure/team_repository.go
@@ -15,12 +15,12 @@ type TeamRepository struct {
 
 // InsertTeamPitchings チーム投手成績をDBに登録する
 func (Repository *TeamRepository) InsertTeamPitchings(pitching teamData.TeamPitching) {
-	stmt, err := Repository.Conn.Prepare("INSERT INTO team_pitching(team_id, year, earned_run_average, games, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, intentional_walk, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)")
+	stmt, err := Repository.Conn.Prepare("INSERT INTO team_pitching(team_id, year, earned_run_average, games, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, intentional_walk, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
-	if _, err := stmt.Exec(pitching.TeamID, pitching.Year, pitching.EarnedRunAverage, pitching.Games, pitching.Win, pitching.Lose, pitching.Save, pitching.Hold, pitching.HoldPoint, pitching.CompleteGame, pitching.Shutout, pitching.NoWalks, pitching.WinningRate, pitching.Batter, pitching.InningsPitched, pitching.Hit, pitching.HomeRun, pitching.BaseOnBalls, pitching.IntentionalWalk, pitching.HitByPitches, pitching.StrikeOut, pitching.WildPitches, pitching.Balk, pitching.RunsAllowed, pitching.EarnedRun); err != nil {
+	if _, err := stmt.Exec(pitching.TeamID, pitching.Year, pitching.EarnedRunAverage, pitching.Games, pitching.Win, pitching.Lose, pitching.Save, pitching.Hold, pitching.HoldPoint, pitching.CompleteGame, pitching.Shutout, pitching.NoWalks, pitching.WinningRate, pitching.Batter, pitching.InningsPitched, pitching.Hit, pitching.HomeRun, pitching.BaseOnBalls, pitching.IntentionalWalk, pitching.HitByPitches, pitching.StrikeOut, pitching.WildPitches, pitching.Balk, pitching.RunsAllowed, pitching.EarnedRun, pitching.BABIP); err != nil {
 		fmt.Println(pitching.TeamID + ":" + pitching.Year)
 		log.Print(err)
 	}
@@ -59,12 +59,12 @@ func (Repository *TeamRepository) GetTeamPitchings(years []int) (teamPitchingMap
 
 // InsertTeamBattings チーム打撃成績をDBに登録する
 func (Repository *TeamRepository) InsertTeamBattings(batting teamData.TeamBatting) {
-	stmt, err := Repository.Conn.Prepare("INSERT INTO team_batting(team_id, year, batting_average, games, plate_appearance, at_bat, score, hit, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, intentional_walk, hit_by_pitches, strike_out, grounded_into_double_play, slugging_percentage, on_base_percentage) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)")
+	stmt, err := Repository.Conn.Prepare("INSERT INTO team_batting(team_id, year, batting_average, games, plate_appearance, at_bat, score, hit, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, intentional_walk, hit_by_pitches, strike_out, grounded_into_double_play, slugging_percentage, on_base_percentage, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
-	if _, err := stmt.Exec(batting.TeamID, batting.Year, batting.BattingAverage, batting.Games, batting.PlateAppearance, batting.AtBat, batting.Score, batting.Hit, batting.Double, batting.Triple, batting.HomeRun, batting.BaseHit, batting.RunsBattedIn, batting.StolenBase, batting.CaughtStealing, batting.SacrificeHits, batting.SacrificeFlies, batting.BaseOnBalls, batting.IntentionalWalk, batting.HitByPitches, batting.StrikeOut, batting.GroundedIntoDoublePlay, batting.SluggingPercentage, batting.OnBasePercentage); err != nil {
+	if _, err := stmt.Exec(batting.TeamID, batting.Year, batting.BattingAverage, batting.Games, batting.PlateAppearance, batting.AtBat, batting.Score, batting.Hit, batting.Double, batting.Triple, batting.HomeRun, batting.BaseHit, batting.RunsBattedIn, batting.StolenBase, batting.CaughtStealing, batting.SacrificeHits, batting.SacrificeFlies, batting.BaseOnBalls, batting.IntentionalWalk, batting.HitByPitches, batting.StrikeOut, batting.GroundedIntoDoublePlay, batting.SluggingPercentage, batting.OnBasePercentage, batting.BABIP); err != nil {
 		fmt.Println(batting.TeamID + ":" + batting.Year)
 		log.Print(err)
 	}

--- a/infrastructure/team_repository_test.go
+++ b/infrastructure/team_repository_test.go
@@ -22,7 +22,7 @@ func TestTeamRepository_InsertTeamPitchings_GetTeamPitchings(t *testing.T) {
 			"チーム投手成績取得と登録",
 			args{
 				[]int{2020},
-				createTeamPitching("01", "2020", 3.4, 143, 60, 60, 60, 60, 60, 60, 60, 60, 3.4, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60),
+				createTeamPitching("01", "2020", 3.4, 143, 60, 60, 60, 60, 60, 60, 60, 60, 3.4, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 0.3),
 			},
 		},
 	}
@@ -43,7 +43,7 @@ func TestTeamRepository_InsertTeamPitchings_GetTeamPitchings(t *testing.T) {
 	}
 }
 
-func createTeamPitching(teamID string, year string, earnedRunAverage float64, games int, win int, lose int, save int, hold int, holdPoint int, completeGame int, shutout int, noWalks int, winningRate float64, batter int, inningsPitched int, hit int, homeRun int, baseOnBalls int, intentionalWalk int, hitByPitches int, strikeOut int, wildPitches int, balk int, runsAllowed int, earnedRun int) (teamPitching teamData.TeamPitching) {
+func createTeamPitching(teamID string, year string, earnedRunAverage float64, games int, win int, lose int, save int, hold int, holdPoint int, completeGame int, shutout int, noWalks int, winningRate float64, batter int, inningsPitched int, hit int, homeRun int, baseOnBalls int, intentionalWalk int, hitByPitches int, strikeOut int, wildPitches int, balk int, runsAllowed int, earnedRun int, babip float64) (teamPitching teamData.TeamPitching) {
 	return teamData.TeamPitching{
 		TeamID:           teamID,
 		Year:             year,
@@ -70,6 +70,7 @@ func createTeamPitching(teamID string, year string, earnedRunAverage float64, ga
 		Balk:             balk,
 		RunsAllowed:      runsAllowed,
 		EarnedRun:        earnedRun,
+		BABIP:            babip,
 	}
 }
 
@@ -84,7 +85,7 @@ func TestTeamInteractor_InsertTeamBattings_GetTeamBatting(t *testing.T) {
 		{
 			"チーム打撃成績取得と登録",
 			args{
-				teamBatting: createTeamBatting("01", "2005", 0.301, 144, 360, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 20, 0.21, 0.314),
+				teamBatting: createTeamBatting("01", "2005", 0.301, 144, 360, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 20, 0.21, 0.314, 0.3),
 			},
 		},
 	}
@@ -107,7 +108,7 @@ func TestTeamInteractor_InsertTeamBattings_GetTeamBatting(t *testing.T) {
 	}
 }
 
-func createTeamBatting(teamID string, year string, battingAverage float64, games int, plateAppearance int, atBat int, score int, hit int, double int, triple int, homeRun int, baseHit int, runsBattedIn int, stolenBase int, caughtStealing int, sacrificeHits int, sacrificeFlies int, baseOnBalls int, intentionalWalk int, hitByPitches int, strikeOut int, groundedIntoDoublePlay int, sluggingPercentage float64, onBasePercentage float64) teamData.TeamBatting {
+func createTeamBatting(teamID string, year string, battingAverage float64, games int, plateAppearance int, atBat int, score int, hit int, double int, triple int, homeRun int, baseHit int, runsBattedIn int, stolenBase int, caughtStealing int, sacrificeHits int, sacrificeFlies int, baseOnBalls int, intentionalWalk int, hitByPitches int, strikeOut int, groundedIntoDoublePlay int, sluggingPercentage float64, onBasePercentage float64, babip float64) teamData.TeamBatting {
 	return teamData.TeamBatting{
 		TeamID:                 teamID,
 		Year:                   year,
@@ -133,6 +134,7 @@ func createTeamBatting(teamID string, year string, battingAverage float64, games
 		GroundedIntoDoublePlay: groundedIntoDoublePlay,
 		SluggingPercentage:     sluggingPercentage,
 		OnBasePercentage:       onBasePercentage,
+		BABIP:                  babip,
 	}
 }
 

--- a/infrastructure/team_repository_test.go
+++ b/infrastructure/team_repository_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestTeamRepository_InsertTeamPitchings_GetTeamPitchings(t *testing.T) {
 	type args struct {
-		years         []int
-		teamPitchings []teamData.TeamPitching
+		years        []int
+		teamPitching teamData.TeamPitching
 	}
 	tests := []struct {
 		name string
@@ -22,7 +22,7 @@ func TestTeamRepository_InsertTeamPitchings_GetTeamPitchings(t *testing.T) {
 			"チーム投手成績取得と登録",
 			args{
 				[]int{2020},
-				createTeamPitchings(),
+				createTeamPitching("01", "2020", 3.4, 143, 60, 60, 60, 60, 60, 60, 60, 60, 3.4, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60),
 			},
 		},
 	}
@@ -34,19 +34,12 @@ func TestTeamRepository_InsertTeamPitchings_GetTeamPitchings(t *testing.T) {
 			sqlHandler.Conn = db
 			repository := TeamRepository{SQLHandler: *sqlHandler}
 
-			repository.InsertTeamPitchings(tt.args.teamPitchings)
+			repository.InsertTeamPitchings(tt.args.teamPitching)
 			actual := repository.GetTeamPitchings(tt.args.years)
 
-			assert.Exactly(t, tt.args.teamPitchings, actual["2020"])
+			assert.Exactly(t, tt.args.teamPitching, actual["2020"][0])
 			testUtil.CloseContainer(resource, pool)
 		})
-	}
-}
-
-func createTeamPitchings() (teamPitchings []teamData.TeamPitching) {
-	return []teamData.TeamPitching{
-		createTeamPitching("01", "2020", 3.4, 143, 60, 60, 60, 60, 60, 60, 60, 60, 3.4, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60),
-		createTeamPitching("10", "2020", 3.4, 143, 50, 50, 50, 50, 50, 50, 50, 50, 3.4, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50),
 	}
 }
 
@@ -82,7 +75,7 @@ func createTeamPitching(teamID string, year string, earnedRunAverage float64, ga
 
 func TestTeamInteractor_InsertTeamBattings_GetTeamBatting(t *testing.T) {
 	type args struct {
-		teamBatting []teamData.TeamBatting
+		teamBatting teamData.TeamBatting
 	}
 	tests := []struct {
 		name string
@@ -91,7 +84,7 @@ func TestTeamInteractor_InsertTeamBattings_GetTeamBatting(t *testing.T) {
 		{
 			"チーム打撃成績取得と登録",
 			args{
-				teamBatting: createTeamBattings(),
+				teamBatting: createTeamBatting("01", "2005", 0.301, 144, 360, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 20, 0.21, 0.314),
 			},
 		},
 	}
@@ -107,16 +100,10 @@ func TestTeamInteractor_InsertTeamBattings_GetTeamBatting(t *testing.T) {
 
 			batting := repository.GetTeamBattings([]int{2005})["2005"]
 
-			assert.Equal(t, tt.args.teamBatting, batting)
+			assert.Equal(t, tt.args.teamBatting, batting[0])
 
 			testUtil.CloseContainer(resource, pool)
 		})
-	}
-}
-func createTeamBattings() []teamData.TeamBatting {
-	return []teamData.TeamBatting{
-		createTeamBatting("01", "2005", 0.301, 144, 360, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 20, 0.21, 0.314),
-		createTeamBatting("02", "2005", 0.264, 144, 300, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 20, 0.156, 0.264),
 	}
 }
 

--- a/interfaces/repository/repository.go
+++ b/interfaces/repository/repository.go
@@ -28,9 +28,9 @@ type GradesRepository interface {
 
 // TeamRepository チーム成績データアクセスを管理するインターフェース
 type TeamRepository interface {
-	InsertTeamPitchings(teamPitching []teamData.TeamPitching)
+	InsertTeamPitchings(teamPitching teamData.TeamPitching)
 	GetTeamPitchings(years []int) (teamPitchingMap map[string][]teamData.TeamPitching)
-	InsertTeamBattings(teamBatting []teamData.TeamBatting)
+	InsertTeamBattings(teamBatting teamData.TeamBatting)
 	GetTeamBattings(years []int) (teamBattingMap map[string][]teamData.TeamBatting)
 	GetTeamStats(years []int) (teamStatsMap map[string][]teamData.TeamLeagueStats)
 	InsertPythagoreanExpectation(teamBattings []teamData.TeamBatting, teamPitchings []teamData.TeamPitching)

--- a/interfaces/repository/repository.go
+++ b/interfaces/repository/repository.go
@@ -21,7 +21,7 @@ type GradesRepository interface {
 	ExtractionCareers(careers *[]data.CAREER)
 	InsertCareers(careers []data.CAREER)
 	ExtractionPicherGrades(picherMap *map[string][]data.PICHERGRADES, teamID string)
-	InsertPicherGrades(picherMap map[string][]data.PICHERGRADES)
+	InsertPicherGrades(key string, picher data.PICHERGRADES)
 	ExtractionBatterGrades(batterMap *map[string][]data.BATTERGRADES, teamID string)
 	InsertBatterGrades(playerID string, batterGrades data.BATTERGRADES)
 }

--- a/team/team.go
+++ b/team/team.go
@@ -82,7 +82,9 @@ func (Interactor *TeamInteractor) InsertSeasonMatchResults(csvPath string, years
 func (Interactor *TeamInteractor) InsertTeamPitchings(csvPath string, league string, years []int) {
 	for _, year := range years {
 		teamPitching := Interactor.ReadTeamPitching(csvPath, league, strconv.Itoa(year))
-		Interactor.TeamRepository.InsertTeamPitchings(teamPitching)
+		for _, pitching := range teamPitching {
+			Interactor.TeamRepository.InsertTeamPitchings(pitching)
+		}
 	}
 }
 
@@ -90,7 +92,9 @@ func (Interactor *TeamInteractor) InsertTeamPitchings(csvPath string, league str
 func (Interactor *TeamInteractor) InsertTeamBattings(csvPath string, league string, years []int) {
 	for _, year := range years {
 		teamBatting := Interactor.ReadTeamBatting(csvPath, league, strconv.Itoa(year))
-		Interactor.TeamRepository.InsertTeamBattings(teamBatting)
+		for _, batting := range teamBatting {
+			Interactor.TeamRepository.InsertTeamBattings(batting)
+		}
 	}
 }
 

--- a/team/team.go
+++ b/team/team.go
@@ -83,6 +83,7 @@ func (Interactor *TeamInteractor) InsertTeamPitchings(csvPath string, league str
 	for _, year := range years {
 		teamPitching := Interactor.ReadTeamPitching(csvPath, league, strconv.Itoa(year))
 		for _, pitching := range teamPitching {
+			pitching.SetBABIP()
 			Interactor.TeamRepository.InsertTeamPitchings(pitching)
 		}
 	}
@@ -93,6 +94,7 @@ func (Interactor *TeamInteractor) InsertTeamBattings(csvPath string, league stri
 	for _, year := range years {
 		teamBatting := Interactor.ReadTeamBatting(csvPath, league, strconv.Itoa(year))
 		for _, batting := range teamBatting {
+			batting.SetBABIP()
 			Interactor.TeamRepository.InsertTeamBattings(batting)
 		}
 	}


### PR DESCRIPTION
# BABIPとは
- 以下のサイトの計算式を用いて求める
![image](https://user-images.githubusercontent.com/55987154/162219172-6c604da7-29e0-456c-9779-f549a3108202.png)
https://1point02.jp/op/gnav/glossary/gls_explanation.aspx?eid=20063

# 機能内容
- 野手成績、チーム打撃成績テーブルにBAPIPを追加
- 投手成績、チーム投手成績テーブルに被BAPIPを追加
- DB登録処理にBABIPと被BABIPを追加
- チーム打撃成績、チーム投手成績、個人成績ページにBABIP、被BABIPの表示を追加
![image](https://user-images.githubusercontent.com/55987154/162433422-244f4485-d81a-453f-8306-02c1f5fbb037.png)
![image](https://user-images.githubusercontent.com/55987154/162434581-a2fa5733-56ab-426c-845a-899830d9077d.png)
![image](https://user-images.githubusercontent.com/55987154/162434896-b45b82c8-cd02-4c2b-820b-36187bb73569.png)
![image](https://user-images.githubusercontent.com/55987154/162435853-1bf720cb-d44b-49f4-b68c-7a4747426f81.png)

# バグ対応
- nanを含む個人成績がJSONに変換できていなかったので、0に変換してDBに登録

# リファクタ
- DB登録処理を単一レコードで実施するように処理を統一