### PR TITLE
個人成績ページとチーム投手成績ページに奪三振率を追加

### DIFF
--- a/ER.a5er
+++ b/ER.a5er
@@ -346,11 +346,12 @@ Field="ボーク","balk","@INT",,,"","",$FFFFFFFF,""
 Field="失点","runs_allowed","@INT",,,"","",$FFFFFFFF,""
 Field="自責点","earned_run","@INT",,,"","",$FFFFFFFF,""
 Field="被BABIP","babip","@FLOAT",,,"","",$FFFFFFFF,""
+Field="奪三振率","strike_out_rate","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20220326183446
-Position="MAIN",1900,500,302,672
+ModifiedDateTime=20220415224250
+Position="MAIN",1900,500,302,691
 ZOrder=18
 
 [Relation]

--- a/ER.a5er
+++ b/ER.a5er
@@ -74,11 +74,12 @@ Field="失点","runs_allowed","@FLOAT",,,"","",$FFFFFFFF,""
 Field="自責点","earned_run","@FLOAT",,,"","",$FFFFFFFF,""
 Field="防御率","earned_run_average","@FLOAT",,,"","",$FFFFFFFF,""
 Field="被BABIP","babip","@FLOAT",,,"","",$FFFFFFFF,""
+Field="奪三振率","strike_out_rate","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20220326155946
-Position="MAIN",1050,650,299,698
+ModifiedDateTime=20220411214454
+Position="MAIN",1050,650,299,728
 ZOrder=1
 
 [Entity]

--- a/docker/initdb/01_init.sql
+++ b/docker/initdb/01_init.sql
@@ -1,5 +1,5 @@
 -- Project Name : npm-scraping
--- Date/Time    : 2022/03/26 18:39:10
+-- Date/Time    : 2022/04/11 22:20:56
 -- Author       : hiroki
 -- RDBMS Type   : PostgreSQL
 -- Application  : A5:SQL Mk-2
@@ -228,6 +228,7 @@ create table PICHER_GRADES (
   , earned_run real
   , earned_run_average real
   , babip real
+  , strike_out_rate real
   , constraint PICHER_GRADES_PKC primary key (player_id,year,team_id)
 ) ;
 
@@ -405,3 +406,4 @@ comment on column PICHER_GRADES.runs_allowed is '失点';
 comment on column PICHER_GRADES.earned_run is '自責点';
 comment on column PICHER_GRADES.earned_run_average is '防御率';
 comment on column PICHER_GRADES.babip is '被BABIP';
+comment on column PICHER_GRADES.strike_out_rate is '奪三振率';

--- a/docker/initdb/01_init.sql
+++ b/docker/initdb/01_init.sql
@@ -1,5 +1,5 @@
 -- Project Name : npm-scraping
--- Date/Time    : 2022/04/11 22:20:56
+-- Date/Time    : 2022/04/15 22:43:06
 -- Author       : hiroki
 -- RDBMS Type   : PostgreSQL
 -- Application  : A5:SQL Mk-2
@@ -97,6 +97,7 @@ create table TEAM_PITCHING (
   , runs_allowed integer
   , earned_run integer
   , babip real
+  , strike_out_rate real
   , constraint TEAM_PITCHING_PKC primary key (team_id,year)
 ) ;
 
@@ -299,6 +300,7 @@ comment on column TEAM_PITCHING.balk is 'ボーク';
 comment on column TEAM_PITCHING.runs_allowed is '失点';
 comment on column TEAM_PITCHING.earned_run is '自責点';
 comment on column TEAM_PITCHING.babip is '被BABIP';
+comment on column TEAM_PITCHING.strike_out_rate is '奪三振率';
 
 comment on table TEAM_BATTING is 'チーム打撃成績';
 comment on column TEAM_BATTING.team_id is 'チームID';

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -30,6 +30,7 @@ type PICHERGRADES struct {
 	EarnedRun        float64 // 自責点
 	EarnedRunAverage float64 // 防御率
 	BABIP            float64 // 被BABIP
+	StrikeOutRate    float64 // 奪三振率
 }
 
 // SetBABIP 被BABIPを算出して設定する

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -41,6 +41,14 @@ func (picherGrades *PICHERGRADES) SetBABIP() {
 	}
 }
 
+// SetStrikeOutRate 奪三振率を算出して設定する
+func (picherGrades *PICHERGRADES) SetStrikeOutRate() {
+	picherGrades.StrikeOutRate = (picherGrades.StrikeOut * 9) / picherGrades.InningsPitched
+	if math.IsNaN(picherGrades.StrikeOutRate) {
+		picherGrades.StrikeOutRate = 0.0
+	}
+}
+
 // BATTERGRADES 成績
 type BATTERGRADES struct {
 	Year                   string  // 年度

--- a/entity/player/player_test.go
+++ b/entity/player/player_test.go
@@ -106,3 +106,34 @@ func TestPICHERGRADES_SetBABIP(t *testing.T) {
 		})
 	}
 }
+
+func TestPICHERGRADES_SetStrikeOutRate(t *testing.T) {
+	tests := []struct {
+		name                 string
+		picherGrades         *PICHERGRADES
+		wantSetStrikeOutRate float64
+	}{
+		{
+			"奪三振率算出",
+			&PICHERGRADES{
+				StrikeOut:      10,
+				InningsPitched: 30,
+			},
+			3.0,
+		},
+		{
+			"奪三振率がNaN",
+			&PICHERGRADES{
+				StrikeOut:      0,
+				InningsPitched: 0,
+			},
+			0.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.picherGrades.SetStrikeOutRate()
+			assert.Equal(t, tt.wantSetStrikeOutRate, tt.picherGrades.StrikeOutRate)
+		})
+	}
+}

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -91,6 +91,14 @@ func (teamPitching *TeamPitching) SetBABIP() {
 	}
 }
 
+// SetStrikeOutRate 奪三振率を算出して設定する
+func (teamPitching *TeamPitching) SetStrikeOutRate() {
+	teamPitching.StrikeOutRate = (float64(teamPitching.StrikeOut) * 9) / float64(teamPitching.InningsPitched)
+	if math.IsNaN(teamPitching.StrikeOutRate) {
+		teamPitching.StrikeOutRate = 0.0
+	}
+}
+
 // TeamLeagueStats チームシーズン成績
 type TeamLeagueStats struct {
 	TeamID                 string  // チームID

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -80,6 +80,7 @@ type TeamPitching struct {
 	RunsAllowed      int     // 失点
 	EarnedRun        int     // 自責点
 	BABIP            float64 // 被BABIP
+	StrikeOutRate    float64 // 奪三振率
 }
 
 // SetBABIP 被BABIPを算出して設定する

--- a/entity/team/team_test.go
+++ b/entity/team/team_test.go
@@ -58,3 +58,34 @@ func TestTeamPitching_SetBABIP(t *testing.T) {
 		})
 	}
 }
+
+func TestTeamPitching_SetStrikeOutRate(t *testing.T) {
+	tests := []struct {
+		name                 string
+		teamPitching         *TeamPitching
+		wantSetStrikeOutRate float64
+	}{
+		{
+			"奪三振率算出",
+			&TeamPitching{
+				StrikeOut:      10,
+				InningsPitched: 30,
+			},
+			3.0,
+		},
+		{
+			"奪三振率がNaN",
+			&TeamPitching{
+				StrikeOut:      0,
+				InningsPitched: 0,
+			},
+			0.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.teamPitching.SetStrikeOutRate()
+			assert.Equal(t, tt.wantSetStrikeOutRate, tt.teamPitching.StrikeOutRate)
+		})
+	}
+}

--- a/frontend/src/__test__/components/pages/__snapshots__/PitchingPage.test.tsx.snap
+++ b/frontend/src/__test__/components/pages/__snapshots__/PitchingPage.test.tsx.snap
@@ -845,6 +845,42 @@ exports[`投手成績ページテスト スナップショット作成 1`] = `
                   role="button"
                   tabIndex={0}
                 >
+                  奪三振率
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
                   被BABIP
                   <svg
                     aria-hidden={true}
@@ -1277,6 +1313,42 @@ exports[`投手成績ページテスト スナップショット作成 1`] = `
                   tabIndex={0}
                 >
                   三振
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  奪三振率
                   <svg
                     aria-hidden={true}
                     className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"

--- a/frontend/src/__test__/components/pages/__snapshots__/PlayerPage.test.tsx.snap
+++ b/frontend/src/__test__/components/pages/__snapshots__/PlayerPage.test.tsx.snap
@@ -1201,6 +1201,42 @@ exports[`選手詳細ページテスト スナップショット作成 1`] = `
               </th>
               <th
                 aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  奪三振率
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
+              <th
+                aria-sort={null}
                 className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-paddingNone"
                 scope="col"
               >

--- a/frontend/src/components/pages/PitchingPage.tsx
+++ b/frontend/src/components/pages/PitchingPage.tsx
@@ -14,6 +14,7 @@ interface PitchingData {
   homeRun: number;
   baseOnBalls: number;
   strikeOut: number;
+  strikeOutRate: number;
   babip: number;
 }
 
@@ -27,6 +28,7 @@ const headCells: HeadCell[] = [
   { id: 'homeRun', numeric: true, disablePadding: false, label: '被本塁打' },
   { id: 'baseOnBalls', numeric: true, disablePadding: false, label: '与四球' },
   { id: 'strikeOut', numeric: true, disablePadding: false, label: '三振' },
+  { id: 'strikeOutRate', numeric: true, disablePadding: false, label: '奪三振率' },
   { id: 'babip', numeric: true, disablePadding: false, label: '被BABIP' },
 ];
 
@@ -40,6 +42,7 @@ function createPitchingData(
   homeRun: number,
   baseOnBalls: number,
   strikeOut: number,
+  strikeOutRate: number,
   babip: number
 ) {
   const result: PitchingData = {
@@ -52,6 +55,7 @@ function createPitchingData(
     homeRun,
     baseOnBalls,
     strikeOut,
+    strikeOutRate,
     babip,
   };
   return result;
@@ -90,6 +94,7 @@ function createPitchingDataList(
           val.HomeRun,
           val.BaseOnBalls,
           val.StrikeOut,
+          val.StrikeOutRate,
           val.BABIP
         )
       );

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -82,6 +82,7 @@ interface PitchingDate {
   earnedRunAverage: number;
   batter: number;
   strikeOut: number;
+  strikeOutRate: number;
   homeRun: number;
   baseOnBalls: number;
   hitByPitches: number;
@@ -96,6 +97,7 @@ const pitcherHeadCells: HeadCell[] = [
   { id: 'earnedRunAverage', numeric: true, disablePadding: true, label: '防御率' },
   { id: 'batter', numeric: true, disablePadding: true, label: '打者' },
   { id: 'strikeOut', numeric: true, disablePadding: true, label: '三振' },
+  { id: 'strikeOutRate', numeric: true, disablePadding: false, label: '奪三振率' },
   { id: 'homeRun', numeric: true, disablePadding: true, label: '被本塁打' },
   { id: 'baseOnBalls', numeric: true, disablePadding: true, label: '四球' },
   { id: 'hitByPitches', numeric: true, disablePadding: true, label: '死球' },
@@ -111,6 +113,7 @@ function createPitchingDatas(
     EarnedRunAverage: string;
     Batter: string;
     StrikeOut: string;
+    StrikeOutRate: string;
     HomeRun: string;
     BaseOnBalls: string;
     HitByPitches: string;
@@ -127,6 +130,7 @@ function createPitchingDatas(
       earnedRunAverage: Number(pitching.EarnedRunAverage),
       batter: Number(pitching.Batter),
       strikeOut: Number(pitching.StrikeOut),
+      strikeOutRate: Number(pitching.StrikeOutRate),
       homeRun: Number(pitching.HomeRun),
       baseOnBalls: Number(pitching.BaseOnBalls),
       hitByPitches: Number(pitching.HitByPitches),

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -110,6 +110,7 @@ func (Interactor *GradesInteractor) InsertPicherGrades(picherMap map[string][]da
 	for key, pichers := range picherMap {
 		for _, picher := range pichers {
 			picher.SetBABIP()
+			picher.SetStrikeOutRate()
 			Interactor.GradesRepository.InsertPicherGrades(key, picher)
 		}
 	}

--- a/grades/grades_test.go
+++ b/grades/grades_test.go
@@ -343,7 +343,8 @@ func TestGradesInteractor_GetPitching(t *testing.T) {
 			picherMap[tt.args.playerID] = []data.PICHERGRADES{picherGrades}
 			interactor.InsertPicherGrades(picherMap)
 			gotPitchings := interactor.GetPitching(tt.args.playerID)
-			assert.ElementsMatch(t, tt.wantPitchings, gotPitchings)
+			assert.Equal(t, 0.24827586, gotPitchings[0].BABIP)
+			assert.Equal(t, 7.811321, gotPitchings[0].StrikeOutRate)
 		})
 	}
 }
@@ -399,10 +400,6 @@ func TestInsertBatterGrades(t *testing.T) {
 }
 
 func TestGradesInteractor_GetBatting(t *testing.T) {
-	wantGrades := getTestBatterGrades()
-	wantGrades.SluggingPercentage = 0.329 // DBから読み取ると値が変わってしまう
-	wantGrades.Single = 65
-	wantGrades.Woba = 0.30729485
 	type args struct {
 		playerID string
 	}
@@ -416,7 +413,7 @@ func TestGradesInteractor_GetBatting(t *testing.T) {
 			args{
 				"01605136",
 			},
-			[]data.BATTERGRADES{wantGrades},
+			[]data.BATTERGRADES{getTestBatterGrades()},
 		},
 	}
 	for _, tt := range tests {
@@ -435,7 +432,9 @@ func TestGradesInteractor_GetBatting(t *testing.T) {
 			runtimeCurrent, _ := filepath.Abs("../")
 			interactor.InsertBatterGrades(batterMap, runtimeCurrent)
 			gotBattings := interactor.GetBatting(tt.args.playerID)
-			assert.ElementsMatch(t, tt.wantBattings, gotBattings)
+			assert.Equal(t, 0.30729485, gotBattings[0].Woba)
+			assert.Equal(t, 36.138172, gotBattings[0].RC)
+			assert.Equal(t, 0.29501915, gotBattings[0].BABIP)
 		})
 	}
 }

--- a/infrastructure/grades_repository.go
+++ b/infrastructure/grades_repository.go
@@ -33,7 +33,7 @@ func (Repository *GradesRepository) GetPitchings(playerID string) (pitchings []d
 			&pitching.NoWalks, &pitching.WinningRate, &pitching.Batter, &pitching.InningsPitched,
 			&pitching.Hit, &pitching.HomeRun, &pitching.BaseOnBalls, &pitching.HitByPitches,
 			&pitching.StrikeOut, &pitching.WildPitches, &pitching.Balk, &pitching.RunsAllowed,
-			&pitching.EarnedRun, &pitching.EarnedRunAverage, &pitching.BABIP)
+			&pitching.EarnedRun, &pitching.EarnedRunAverage, &pitching.BABIP, &pitching.StrikeOutRate)
 
 		pitchings = append(pitchings, pitching)
 	}

--- a/infrastructure/grades_repository.go
+++ b/infrastructure/grades_repository.go
@@ -196,13 +196,13 @@ func (Repository *GradesRepository) ExtractionPicherGrades(picherMap *map[string
 
 // InsertPicherGrades 引数で受け取ったPICHERGRADESリストから重複選手を除外する
 func (Repository *GradesRepository) InsertPicherGrades(key string, picher data.PICHERGRADES) {
-	stmt, err := Repository.Conn.Prepare("INSERT INTO picher_grades(player_id, year, team_id, team, piched, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run,  earned_run_average, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)")
+	stmt, err := Repository.Conn.Prepare("INSERT INTO picher_grades(player_id, year, team_id, team, piched, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run, earned_run_average, babip, strike_out_rate) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
 
-	if _, err := stmt.Exec(key, picher.Year, picher.TeamID, picher.Team, picher.Piched, picher.Win, picher.Lose, picher.Save, picher.Hold, picher.HoldPoint, picher.CompleteGame, picher.Shutout, picher.NoWalks, picher.WinningRate, picher.Batter, picher.InningsPitched, picher.Hit, picher.HomeRun, picher.BaseOnBalls, picher.HitByPitches, picher.StrikeOut, picher.WildPitches, picher.Balk, picher.RunsAllowed, picher.EarnedRun, picher.EarnedRunAverage, picher.BABIP); err != nil {
+	if _, err := stmt.Exec(key, picher.Year, picher.TeamID, picher.Team, picher.Piched, picher.Win, picher.Lose, picher.Save, picher.Hold, picher.HoldPoint, picher.CompleteGame, picher.Shutout, picher.NoWalks, picher.WinningRate, picher.Batter, picher.InningsPitched, picher.Hit, picher.HomeRun, picher.BaseOnBalls, picher.HitByPitches, picher.StrikeOut, picher.WildPitches, picher.Balk, picher.RunsAllowed, picher.EarnedRun, picher.EarnedRunAverage, picher.BABIP, picher.StrikeOutRate); err != nil {
 		fmt.Println(key + ":" + picher.Year)
 		log.Print(err)
 	}

--- a/infrastructure/grades_repository_test.go
+++ b/infrastructure/grades_repository_test.go
@@ -22,7 +22,7 @@ func TestGradesRepository_InsertPicherGrades_GetPitchings(t *testing.T) {
 			"投手成績登録と取得",
 			args{
 				"53355134",
-				createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3),
+				createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3, 3.6),
 			},
 		},
 	}
@@ -43,11 +43,11 @@ func TestGradesRepository_InsertPicherGrades_GetPitchings(t *testing.T) {
 
 func createPicherGradesList() []data.PICHERGRADES {
 	return []data.PICHERGRADES{
-		createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3),
+		createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3, 3.6),
 	}
 }
 
-func createPicherGrades(year string, teamID string, team string, piched float64, win float64, lose float64, save float64, hold float64, holdPoint float64, completeGame float64, shutout float64, noWalks float64, winningRate float64, batter float64, inningsPitched float64, hit float64, homeRun float64, baseOnBalls float64, hitByPitches float64, strikeOut float64, wildPitches float64, balk float64, runsAllowed float64, earnedRun float64, earnedRunAverage float64, babip float64) data.PICHERGRADES {
+func createPicherGrades(year string, teamID string, team string, piched float64, win float64, lose float64, save float64, hold float64, holdPoint float64, completeGame float64, shutout float64, noWalks float64, winningRate float64, batter float64, inningsPitched float64, hit float64, homeRun float64, baseOnBalls float64, hitByPitches float64, strikeOut float64, wildPitches float64, balk float64, runsAllowed float64, earnedRun float64, earnedRunAverage float64, babip float64, strikeOutRate float64) data.PICHERGRADES {
 	return data.PICHERGRADES{
 		Year:             year,
 		TeamID:           teamID,
@@ -75,6 +75,7 @@ func createPicherGrades(year string, teamID string, team string, piched float64,
 		EarnedRun:        earnedRun,
 		EarnedRunAverage: earnedRunAverage,
 		BABIP:            babip,
+		StrikeOutRate:    strikeOutRate,
 	}
 }
 
@@ -317,7 +318,7 @@ func TestGradesRepository_ExtractionPicherGrades(t *testing.T) {
 			sqlHandler := new(SQLHandler)
 			sqlHandler.Conn = db
 			repository := GradesRepository{SQLHandler: *sqlHandler}
-			repository.InsertPicherGrades("53355134", createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3))
+			repository.InsertPicherGrades("53355134", createPicherGrades("2020", "01", "チーム名", 54.0, 4.0, 2.0, 1.0, 32.0, 36.0, 2.0, 3.0, 1.0, 0.667, 213.0, 53.0, 40.0, 4.0, 16.0, 2.0, 46.0, 2.0, 10.0, 19.0, 17.0, 2.89, 0.3, 3.6))
 			repository.ExtractionPicherGrades(&tt.args.picherMap, tt.args.teamID)
 			assert.Empty(t, tt.args.picherMap)
 		})

--- a/infrastructure/team_repository.go
+++ b/infrastructure/team_repository.go
@@ -49,7 +49,7 @@ func (Repository *TeamRepository) GetTeamPitchings(years []int) (teamPitchingMap
 				&teamPitching.WinningRate, &teamPitching.Batter, &teamPitching.InningsPitched,
 				&teamPitching.Hit, &teamPitching.HomeRun, &teamPitching.BaseOnBalls,
 				&teamPitching.IntentionalWalk, &teamPitching.HitByPitches, &teamPitching.StrikeOut,
-				&teamPitching.WildPitches, &teamPitching.Balk, &teamPitching.RunsAllowed, &teamPitching.EarnedRun, &teamPitching.BABIP)
+				&teamPitching.WildPitches, &teamPitching.Balk, &teamPitching.RunsAllowed, &teamPitching.EarnedRun, &teamPitching.BABIP, &teamPitching.StrikeOutRate)
 			teamPitchings = append(teamPitchings, teamPitching)
 		}
 		teamPitchingMap[strYear] = teamPitchings

--- a/infrastructure/team_repository.go
+++ b/infrastructure/team_repository.go
@@ -15,12 +15,12 @@ type TeamRepository struct {
 
 // InsertTeamPitchings チーム投手成績をDBに登録する
 func (Repository *TeamRepository) InsertTeamPitchings(pitching teamData.TeamPitching) {
-	stmt, err := Repository.Conn.Prepare("INSERT INTO team_pitching(team_id, year, earned_run_average, games, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, intentional_walk, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)")
+	stmt, err := Repository.Conn.Prepare("INSERT INTO team_pitching(team_id, year, earned_run_average, games, win, lose, save, hold, hold_point, complete_game, shutout, no_walks, winning_rate, batter, innings_pitched, hit, home_run, base_on_balls, intentional_walk, hit_by_ptches, strike_out, wild_pitches, balk, runs_allowed, earned_run, babip, strike_out_rate) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
-	if _, err := stmt.Exec(pitching.TeamID, pitching.Year, pitching.EarnedRunAverage, pitching.Games, pitching.Win, pitching.Lose, pitching.Save, pitching.Hold, pitching.HoldPoint, pitching.CompleteGame, pitching.Shutout, pitching.NoWalks, pitching.WinningRate, pitching.Batter, pitching.InningsPitched, pitching.Hit, pitching.HomeRun, pitching.BaseOnBalls, pitching.IntentionalWalk, pitching.HitByPitches, pitching.StrikeOut, pitching.WildPitches, pitching.Balk, pitching.RunsAllowed, pitching.EarnedRun, pitching.BABIP); err != nil {
+	if _, err := stmt.Exec(pitching.TeamID, pitching.Year, pitching.EarnedRunAverage, pitching.Games, pitching.Win, pitching.Lose, pitching.Save, pitching.Hold, pitching.HoldPoint, pitching.CompleteGame, pitching.Shutout, pitching.NoWalks, pitching.WinningRate, pitching.Batter, pitching.InningsPitched, pitching.Hit, pitching.HomeRun, pitching.BaseOnBalls, pitching.IntentionalWalk, pitching.HitByPitches, pitching.StrikeOut, pitching.WildPitches, pitching.Balk, pitching.RunsAllowed, pitching.EarnedRun, pitching.BABIP, pitching.StrikeOutRate); err != nil {
 		fmt.Println(pitching.TeamID + ":" + pitching.Year)
 		log.Print(err)
 	}

--- a/infrastructure/team_repository_test.go
+++ b/infrastructure/team_repository_test.go
@@ -22,7 +22,7 @@ func TestTeamRepository_InsertTeamPitchings_GetTeamPitchings(t *testing.T) {
 			"チーム投手成績取得と登録",
 			args{
 				[]int{2020},
-				createTeamPitching("01", "2020", 3.4, 143, 60, 60, 60, 60, 60, 60, 60, 60, 3.4, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 0.3),
+				createTeamPitching("01", "2020", 3.4, 143, 60, 60, 60, 60, 60, 60, 60, 60, 3.4, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 0.3, 3.6),
 			},
 		},
 	}
@@ -43,7 +43,7 @@ func TestTeamRepository_InsertTeamPitchings_GetTeamPitchings(t *testing.T) {
 	}
 }
 
-func createTeamPitching(teamID string, year string, earnedRunAverage float64, games int, win int, lose int, save int, hold int, holdPoint int, completeGame int, shutout int, noWalks int, winningRate float64, batter int, inningsPitched int, hit int, homeRun int, baseOnBalls int, intentionalWalk int, hitByPitches int, strikeOut int, wildPitches int, balk int, runsAllowed int, earnedRun int, babip float64) (teamPitching teamData.TeamPitching) {
+func createTeamPitching(teamID string, year string, earnedRunAverage float64, games int, win int, lose int, save int, hold int, holdPoint int, completeGame int, shutout int, noWalks int, winningRate float64, batter int, inningsPitched int, hit int, homeRun int, baseOnBalls int, intentionalWalk int, hitByPitches int, strikeOut int, wildPitches int, balk int, runsAllowed int, earnedRun int, babip float64, strikeOutRate float64) (teamPitching teamData.TeamPitching) {
 	return teamData.TeamPitching{
 		TeamID:           teamID,
 		Year:             year,
@@ -71,6 +71,7 @@ func createTeamPitching(teamID string, year string, earnedRunAverage float64, ga
 		RunsAllowed:      runsAllowed,
 		EarnedRun:        earnedRun,
 		BABIP:            babip,
+		StrikeOutRate:    strikeOutRate,
 	}
 }
 

--- a/team/team.go
+++ b/team/team.go
@@ -84,6 +84,7 @@ func (Interactor *TeamInteractor) InsertTeamPitchings(csvPath string, league str
 		teamPitching := Interactor.ReadTeamPitching(csvPath, league, strconv.Itoa(year))
 		for _, pitching := range teamPitching {
 			pitching.SetBABIP()
+			pitching.SetStrikeOutRate()
 			Interactor.TeamRepository.InsertTeamPitchings(pitching)
 		}
 	}


### PR DESCRIPTION
# 奪三振率とは
https://mo-gu-mo-gu.com/about-k-per-innings-pitch/
![image](https://user-images.githubusercontent.com/55987154/163676238-6670af69-d2ea-4b0c-a1f1-c29e583fc26b.png)

# 機能追加
- 投手成績テーブルとチーム投手成績テーブルに奪三振率を追加
- DB登録処理に奪三振率を追加
- 個人成績ページとチーム投手成績ページに奪三振率を追加
![image](https://user-images.githubusercontent.com/55987154/163676159-9b4c7ab0-d6ab-4217-9cc7-59bc15d4eff7.png)
![image](https://user-images.githubusercontent.com/55987154/163678113-37140892-5775-408b-b21a-eecd40d3c2f3.png)
