### PR TITLE
打撃成績、野手成績に三振率を追加

### DIFF
--- a/ER.a5er
+++ b/ER.a5er
@@ -1,7 +1,7 @@
 ﻿# A5:ER FORMAT:16
 # A5:ER ENCODING:UTF8
 # A5:ER Mk-1 Copyright © 2007 m.matsubara
-# A5:SQL Mk-2 Version 2.17.1 Copyright © 1997 - 2022 m.matsubara
+# A5:SQL Mk-2 Version 2.17.2 Copyright © 1997 - 2022 m.matsubara
 #  https://a5m2.mmatsubara.com
 
 [Manager]
@@ -158,6 +158,7 @@ Field="犠飛","sacrifice_flies","@INT",,,"","",$FFFFFFFF,""
 Field="四球","base_on_balls","@INT",,,"","",$FFFFFFFF,""
 Field="死球","hit_by_pitches","@INT",,,"","",$FFFFFFFF,""
 Field="三振","strike_out","@INT",,,"","",$FFFFFFFF,""
+Field="三振率","strike_out_rate","@FLOAT",,,"","",$FFFFFFFF,""
 Field="併殺打","grounded_into_double_play","@INT",,,"","",$FFFFFFFF,""
 Field="打率","batting_average","@FLOAT",,,"","",$FFFFFFFF,""
 Field="長打率","slugging_percentage","@FLOAT",,,"","",$FFFFFFFF,""
@@ -168,8 +169,8 @@ Field="BABIP","babip","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20220326183734
-Position="MAIN",550,650,275,749
+ModifiedDateTime=20220607225436
+Position="MAIN",550,650,275,773
 ZOrder=5
 
 [Relation]
@@ -279,6 +280,7 @@ Field="四球","base_on_balls","@INT",,,"","",$FFFFFFFF,""
 Field="故意四","intentional_walk","@INT",,,"","",$FFFFFFFF,""
 Field="死球","hit_by_pitches","@INT",,,"","",$FFFFFFFF,""
 Field="三振","strike_out","@INT",,,"","",$FFFFFFFF,""
+Field="三振率","strike_out_rate","@FLOAT",,,"","",$FFFFFFFF,""
 Field="併殺打","grounded_into_double_play","@INT",,,"","",$FFFFFFFF,""
 Field="長打率","slugging_percentage","@FLOAT",,,"","",$FFFFFFFF,""
 Field="出塁率","on_base_percentage","@FLOAT",,,"","",$FFFFFFFF,""
@@ -286,8 +288,8 @@ Field="BABIP","babip","@FLOAT",,,"","",$FFFFFFFF,""
 EffectMode=None
 Color=$000000
 BkColor=$FFFFFF
-ModifiedDateTime=20220326183751
-Position="MAIN",1500,500,298,646
+ModifiedDateTime=20220608230400
+Position="MAIN",1500,500,298,669
 ZOrder=16
 
 [Relation]

--- a/docker/initdb/01_init.sql
+++ b/docker/initdb/01_init.sql
@@ -1,5 +1,5 @@
 -- Project Name : npm-scraping
--- Date/Time    : 2022/04/15 22:43:06
+-- Date/Time    : 2022/06/08 23:04:29
 -- Author       : hiroki
 -- RDBMS Type   : PostgreSQL
 -- Application  : A5:SQL Mk-2
@@ -125,6 +125,7 @@ create table TEAM_BATTING (
   , intentional_walk integer
   , hit_by_pitches integer
   , strike_out integer
+  , strike_out_rate real
   , grounded_into_double_play integer
   , slugging_percentage real
   , on_base_percentage real
@@ -174,6 +175,7 @@ create table BATTER_GRADES (
   , base_on_balls integer
   , hit_by_pitches integer
   , strike_out integer
+  , strike_out_rate real
   , grounded_into_double_play integer
   , batting_average real
   , slugging_percentage real
@@ -324,6 +326,7 @@ comment on column TEAM_BATTING.base_on_balls is '四球';
 comment on column TEAM_BATTING.intentional_walk is '故意四';
 comment on column TEAM_BATTING.hit_by_pitches is '死球';
 comment on column TEAM_BATTING.strike_out is '三振';
+comment on column TEAM_BATTING.strike_out_rate is '三振率';
 comment on column TEAM_BATTING.grounded_into_double_play is '併殺打';
 comment on column TEAM_BATTING.slugging_percentage is '長打率';
 comment on column TEAM_BATTING.on_base_percentage is '出塁率';
@@ -361,6 +364,7 @@ comment on column BATTER_GRADES.sacrifice_flies is '犠飛';
 comment on column BATTER_GRADES.base_on_balls is '四球';
 comment on column BATTER_GRADES.hit_by_pitches is '死球';
 comment on column BATTER_GRADES.strike_out is '三振';
+comment on column BATTER_GRADES.strike_out_rate is '三振率';
 comment on column BATTER_GRADES.grounded_into_double_play is '併殺打';
 comment on column BATTER_GRADES.batting_average is '打率';
 comment on column BATTER_GRADES.slugging_percentage is '長打率';

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -1,6 +1,9 @@
 package player
 
-import "math"
+import (
+	"database/sql"
+	"math"
+)
 
 // PICHERGRADES 成績
 type PICHERGRADES struct {
@@ -51,34 +54,35 @@ func (picherGrades *PICHERGRADES) SetStrikeOutRate() {
 
 // BATTERGRADES 成績
 type BATTERGRADES struct {
-	Year                   string  // 年度
-	TeamID                 string  // チームID
-	Team                   string  // 所属球団
-	Games                  int     // 試合
-	PlateAppearance        int     // 打席
-	AtBat                  int     // 打数
-	Score                  int     // 得点
-	Hit                    int     // 安打
-	Single                 int     //単打
-	Double                 int     // 二塁打
-	Triple                 int     // 三塁打
-	HomeRun                int     // 本塁打
-	BaseHit                int     // 塁打
-	RunsBattedIn           int     // 打点
-	StolenBase             int     // 盗塁
-	CaughtStealing         int     // 盗塁刺
-	SacrificeHits          int     // 犠打
-	SacrificeFlies         int     // 犠飛
-	BaseOnBalls            int     // 四球
-	HitByPitches           int     // 死球
-	StrikeOut              int     // 三振
-	GroundedIntoDoublePlay int     // 併殺打
-	BattingAverage         float64 // 打率
-	SluggingPercentage     float64 // 長打率
-	OnBasePercentage       float64 // 出塁率
-	Woba                   float64 // 加重出塁率
-	RC                     float64 // 創出得点
-	BABIP                  float64 // BABIP
+	Year                   string          // 年度
+	TeamID                 string          // チームID
+	Team                   string          // 所属球団
+	Games                  int             // 試合
+	PlateAppearance        int             // 打席
+	AtBat                  int             // 打数
+	Score                  int             // 得点
+	Hit                    int             // 安打
+	Single                 int             // 単打
+	Double                 int             // 二塁打
+	Triple                 int             // 三塁打
+	HomeRun                int             // 本塁打
+	BaseHit                int             // 塁打
+	RunsBattedIn           int             // 打点
+	StolenBase             int             // 盗塁
+	CaughtStealing         int             // 盗塁刺
+	SacrificeHits          int             // 犠打
+	SacrificeFlies         int             // 犠飛
+	BaseOnBalls            int             // 四球
+	HitByPitches           int             // 死球
+	StrikeOut              int             // 三振
+	StrikeOutRate          sql.NullFloat64 // 三振率
+	GroundedIntoDoublePlay int             // 併殺打
+	BattingAverage         float64         // 打率
+	SluggingPercentage     float64         // 長打率
+	OnBasePercentage       float64         // 出塁率
+	Woba                   float64         // 加重出塁率
+	RC                     float64         // 創出得点
+	BABIP                  float64         // BABIP
 }
 
 // SetRC RCを算出して設定する

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -85,6 +85,19 @@ type BATTERGRADES struct {
 	BABIP                  float64         // BABIP
 }
 
+// SetStrikeOutRate 三振率を算出して設定する
+func (batterGrades *BATTERGRADES) SetStrikeOutRate() {
+	strikeOutRate := (float64(batterGrades.StrikeOut)) / float64(batterGrades.PlateAppearance)
+
+	if math.IsNaN(strikeOutRate) {
+		strikeOutRate = 0.0
+	}
+
+	batterGrades.StrikeOutRate = sql.NullFloat64{
+		Float64: strikeOutRate,
+	}
+}
+
 // SetRC RCを算出して設定する
 func (batterGrades *BATTERGRADES) SetRC() {
 	A := float64(batterGrades.Hit + batterGrades.BaseOnBalls + batterGrades.HitByPitches - batterGrades.CaughtStealing - batterGrades.GroundedIntoDoublePlay)

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -95,6 +95,7 @@ func (batterGrades *BATTERGRADES) SetStrikeOutRate() {
 
 	batterGrades.StrikeOutRate = sql.NullFloat64{
 		Float64: strikeOutRate,
+		Valid:   true,
 	}
 }
 

--- a/entity/player/player.go
+++ b/entity/player/player.go
@@ -3,6 +3,8 @@ package player
 import (
 	"database/sql"
 	"math"
+
+	"github.com/tokuchi765/npb-analysis/entity/sqlwrapper"
 )
 
 // PICHERGRADES 成績
@@ -54,35 +56,35 @@ func (picherGrades *PICHERGRADES) SetStrikeOutRate() {
 
 // BATTERGRADES 成績
 type BATTERGRADES struct {
-	Year                   string          // 年度
-	TeamID                 string          // チームID
-	Team                   string          // 所属球団
-	Games                  int             // 試合
-	PlateAppearance        int             // 打席
-	AtBat                  int             // 打数
-	Score                  int             // 得点
-	Hit                    int             // 安打
-	Single                 int             // 単打
-	Double                 int             // 二塁打
-	Triple                 int             // 三塁打
-	HomeRun                int             // 本塁打
-	BaseHit                int             // 塁打
-	RunsBattedIn           int             // 打点
-	StolenBase             int             // 盗塁
-	CaughtStealing         int             // 盗塁刺
-	SacrificeHits          int             // 犠打
-	SacrificeFlies         int             // 犠飛
-	BaseOnBalls            int             // 四球
-	HitByPitches           int             // 死球
-	StrikeOut              int             // 三振
-	StrikeOutRate          sql.NullFloat64 // 三振率
-	GroundedIntoDoublePlay int             // 併殺打
-	BattingAverage         float64         // 打率
-	SluggingPercentage     float64         // 長打率
-	OnBasePercentage       float64         // 出塁率
-	Woba                   float64         // 加重出塁率
-	RC                     float64         // 創出得点
-	BABIP                  float64         // BABIP
+	Year                   string                 // 年度
+	TeamID                 string                 // チームID
+	Team                   string                 // 所属球団
+	Games                  int                    // 試合
+	PlateAppearance        int                    // 打席
+	AtBat                  int                    // 打数
+	Score                  int                    // 得点
+	Hit                    int                    // 安打
+	Single                 int                    // 単打
+	Double                 int                    // 二塁打
+	Triple                 int                    // 三塁打
+	HomeRun                int                    // 本塁打
+	BaseHit                int                    // 塁打
+	RunsBattedIn           int                    // 打点
+	StolenBase             int                    // 盗塁
+	CaughtStealing         int                    // 盗塁刺
+	SacrificeHits          int                    // 犠打
+	SacrificeFlies         int                    // 犠飛
+	BaseOnBalls            int                    // 四球
+	HitByPitches           int                    // 死球
+	StrikeOut              int                    // 三振
+	StrikeOutRate          sqlwrapper.NullFloat64 // 三振率
+	GroundedIntoDoublePlay int                    // 併殺打
+	BattingAverage         float64                // 打率
+	SluggingPercentage     float64                // 長打率
+	OnBasePercentage       float64                // 出塁率
+	Woba                   float64                // 加重出塁率
+	RC                     float64                // 創出得点
+	BABIP                  float64                // BABIP
 }
 
 // SetStrikeOutRate 三振率を算出して設定する
@@ -93,9 +95,11 @@ func (batterGrades *BATTERGRADES) SetStrikeOutRate() {
 		strikeOutRate = 0.0
 	}
 
-	batterGrades.StrikeOutRate = sql.NullFloat64{
-		Float64: strikeOutRate,
-		Valid:   true,
+	batterGrades.StrikeOutRate = sqlwrapper.NullFloat64{
+		NullFloat64: sql.NullFloat64{
+			Float64: strikeOutRate,
+			Valid:   true,
+		},
 	}
 }
 

--- a/entity/player/player_test.go
+++ b/entity/player/player_test.go
@@ -1,6 +1,7 @@
 package player
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -134,6 +135,41 @@ func TestPICHERGRADES_SetStrikeOutRate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.picherGrades.SetStrikeOutRate()
 			assert.Equal(t, tt.wantSetStrikeOutRate, tt.picherGrades.StrikeOutRate)
+		})
+	}
+}
+
+func TestBATTERGRADES_SetStrikeOutRate(t *testing.T) {
+	tests := []struct {
+		name              string
+		batterGrades      *BATTERGRADES
+		wantStrikeOutRate sql.NullFloat64
+	}{
+		{
+			"三振率算出",
+			&BATTERGRADES{
+				StrikeOut:       10,
+				PlateAppearance: 100,
+			},
+			sql.NullFloat64{
+				Float64: 0.1,
+			},
+		},
+		{
+			"三振率がNaN",
+			&BATTERGRADES{
+				StrikeOut:       0,
+				PlateAppearance: 0,
+			},
+			sql.NullFloat64{
+				Float64: 0.0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.batterGrades.SetStrikeOutRate()
+			assert.Equal(t, tt.wantStrikeOutRate, tt.batterGrades.StrikeOutRate)
 		})
 	}
 }

--- a/entity/player/player_test.go
+++ b/entity/player/player_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tokuchi765/npb-analysis/entity/sqlwrapper"
 )
 
 func TestBATTERGRADES_SetRC(t *testing.T) {
@@ -143,7 +144,7 @@ func TestBATTERGRADES_SetStrikeOutRate(t *testing.T) {
 	tests := []struct {
 		name              string
 		batterGrades      *BATTERGRADES
-		wantStrikeOutRate sql.NullFloat64
+		wantStrikeOutRate sqlwrapper.NullFloat64
 	}{
 		{
 			"三振率算出",
@@ -151,8 +152,11 @@ func TestBATTERGRADES_SetStrikeOutRate(t *testing.T) {
 				StrikeOut:       10,
 				PlateAppearance: 100,
 			},
-			sql.NullFloat64{
-				Float64: 0.1,
+			sqlwrapper.NullFloat64{
+				NullFloat64: sql.NullFloat64{
+					Float64: 0.1,
+					Valid:   true,
+				},
 			},
 		},
 		{
@@ -161,8 +165,11 @@ func TestBATTERGRADES_SetStrikeOutRate(t *testing.T) {
 				StrikeOut:       0,
 				PlateAppearance: 0,
 			},
-			sql.NullFloat64{
-				Float64: 0.0,
+			sqlwrapper.NullFloat64{
+				NullFloat64: sql.NullFloat64{
+					Float64: 0.0,
+					Valid:   true,
+				},
 			},
 		},
 	}

--- a/entity/sqlwrapper/sqlwrapper.go
+++ b/entity/sqlwrapper/sqlwrapper.go
@@ -1,0 +1,16 @@
+package sqlwrapper
+
+import (
+	"database/sql"
+	"encoding/json"
+)
+
+// NullFloat64 JSON拡張したNullFloat64
+type NullFloat64 struct {
+	sql.NullFloat64
+}
+
+// MarshalJSON json変換処理
+func (f NullFloat64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.Float64)
+}

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -3,6 +3,8 @@ package team
 import (
 	"database/sql"
 	"math"
+
+	"github.com/tokuchi765/npb-analysis/entity/sqlwrapper"
 )
 
 // TEAMDATA チーム情報
@@ -20,32 +22,32 @@ type TEAMNAME struct {
 
 // TeamBatting チーム打撃成績
 type TeamBatting struct {
-	TeamID                 string          // チームID
-	Year                   string          // 年度
-	BattingAverage         float64         // 打率
-	Games                  int             // 試合
-	PlateAppearance        int             // 打席
-	AtBat                  int             // 打数
-	Score                  int             // 得点
-	Hit                    int             // 安打
-	Double                 int             // 二塁打
-	Triple                 int             // 三塁打
-	HomeRun                int             // 本塁打
-	BaseHit                int             // 塁打
-	RunsBattedIn           int             // 打点
-	StolenBase             int             // 盗塁
-	CaughtStealing         int             // 盗塁刺
-	SacrificeHits          int             // 犠打
-	SacrificeFlies         int             // 犠飛
-	BaseOnBalls            int             // 四球
-	IntentionalWalk        int             // 故意四球
-	HitByPitches           int             // 死球
-	StrikeOut              int             // 三振
-	StrikeOutRate          sql.NullFloat64 // 三振率
-	GroundedIntoDoublePlay int             // 併殺打
-	SluggingPercentage     float64         // 長打率
-	OnBasePercentage       float64         // 出塁率
-	BABIP                  float64         // BABIP
+	TeamID                 string                 // チームID
+	Year                   string                 // 年度
+	BattingAverage         float64                // 打率
+	Games                  int                    // 試合
+	PlateAppearance        int                    // 打席
+	AtBat                  int                    // 打数
+	Score                  int                    // 得点
+	Hit                    int                    // 安打
+	Double                 int                    // 二塁打
+	Triple                 int                    // 三塁打
+	HomeRun                int                    // 本塁打
+	BaseHit                int                    // 塁打
+	RunsBattedIn           int                    // 打点
+	StolenBase             int                    // 盗塁
+	CaughtStealing         int                    // 盗塁刺
+	SacrificeHits          int                    // 犠打
+	SacrificeFlies         int                    // 犠飛
+	BaseOnBalls            int                    // 四球
+	IntentionalWalk        int                    // 故意四球
+	HitByPitches           int                    // 死球
+	StrikeOut              int                    // 三振
+	StrikeOutRate          sqlwrapper.NullFloat64 // 三振率
+	GroundedIntoDoublePlay int                    // 併殺打
+	SluggingPercentage     float64                // 長打率
+	OnBasePercentage       float64                // 出塁率
+	BABIP                  float64                // BABIP
 }
 
 // SetBABIP BABIPを算出して設定する
@@ -64,9 +66,11 @@ func (teamBatting *TeamBatting) SetStrikeOutRate() {
 		strikeOutRate = 0.0
 	}
 
-	teamBatting.StrikeOutRate = sql.NullFloat64{
-		Float64: strikeOutRate,
-		Valid:   true,
+	teamBatting.StrikeOutRate = sqlwrapper.NullFloat64{
+		NullFloat64: sql.NullFloat64{
+			Float64: strikeOutRate,
+			Valid:   true,
+		},
 	}
 }
 

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -1,6 +1,9 @@
 package team
 
-import "math"
+import (
+	"database/sql"
+	"math"
+)
 
 // TEAMDATA チーム情報
 type TEAMDATA struct {
@@ -17,31 +20,32 @@ type TEAMNAME struct {
 
 // TeamBatting チーム打撃成績
 type TeamBatting struct {
-	TeamID                 string  // チームID
-	Year                   string  // 年度
-	BattingAverage         float64 // 打率
-	Games                  int     // 試合
-	PlateAppearance        int     // 打席
-	AtBat                  int     // 打数
-	Score                  int     // 得点
-	Hit                    int     // 安打
-	Double                 int     // 二塁打
-	Triple                 int     // 三塁打
-	HomeRun                int     // 本塁打
-	BaseHit                int     // 塁打
-	RunsBattedIn           int     // 打点
-	StolenBase             int     // 盗塁
-	CaughtStealing         int     // 盗塁刺
-	SacrificeHits          int     // 犠打
-	SacrificeFlies         int     // 犠飛
-	BaseOnBalls            int     // 四球
-	IntentionalWalk        int     // 故意四球
-	HitByPitches           int     // 死球
-	StrikeOut              int     // 三振
-	GroundedIntoDoublePlay int     // 併殺打
-	SluggingPercentage     float64 // 長打率
-	OnBasePercentage       float64 // 出塁率
-	BABIP                  float64 // BABIP
+	TeamID                 string          // チームID
+	Year                   string          // 年度
+	BattingAverage         float64         // 打率
+	Games                  int             // 試合
+	PlateAppearance        int             // 打席
+	AtBat                  int             // 打数
+	Score                  int             // 得点
+	Hit                    int             // 安打
+	Double                 int             // 二塁打
+	Triple                 int             // 三塁打
+	HomeRun                int             // 本塁打
+	BaseHit                int             // 塁打
+	RunsBattedIn           int             // 打点
+	StolenBase             int             // 盗塁
+	CaughtStealing         int             // 盗塁刺
+	SacrificeHits          int             // 犠打
+	SacrificeFlies         int             // 犠飛
+	BaseOnBalls            int             // 四球
+	IntentionalWalk        int             // 故意四球
+	HitByPitches           int             // 死球
+	StrikeOut              int             // 三振
+	StrikeOutRate          sql.NullFloat64 // 三振率
+	GroundedIntoDoublePlay int             // 併殺打
+	SluggingPercentage     float64         // 長打率
+	OnBasePercentage       float64         // 出塁率
+	BABIP                  float64         // BABIP
 }
 
 // SetBABIP BABIPを算出して設定する

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -66,6 +66,7 @@ func (teamBatting *TeamBatting) SetStrikeOutRate() {
 
 	teamBatting.StrikeOutRate = sql.NullFloat64{
 		Float64: strikeOutRate,
+		Valid:   true,
 	}
 }
 

--- a/entity/team/team.go
+++ b/entity/team/team.go
@@ -56,6 +56,19 @@ func (teamBatting *TeamBatting) SetBABIP() {
 	}
 }
 
+// SetStrikeOutRate 三振率を算出して設定する
+func (teamBatting *TeamBatting) SetStrikeOutRate() {
+	strikeOutRate := (float64(teamBatting.StrikeOut)) / float64(teamBatting.PlateAppearance)
+
+	if math.IsNaN(strikeOutRate) {
+		strikeOutRate = 0.0
+	}
+
+	teamBatting.StrikeOutRate = sql.NullFloat64{
+		Float64: strikeOutRate,
+	}
+}
+
 // TeamPitching チーム投手成績
 type TeamPitching struct {
 	TeamID           string  // チームID

--- a/entity/team/team_test.go
+++ b/entity/team/team_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tokuchi765/npb-analysis/entity/sqlwrapper"
 )
 
 func TestTeamBatting_SetBABIP(t *testing.T) {
@@ -95,7 +96,7 @@ func TestTeamBatting_SetStrikeOutRate(t *testing.T) {
 	tests := []struct {
 		name              string
 		teamBatting       *TeamBatting
-		wantStrikeOutRate sql.NullFloat64
+		wantStrikeOutRate sqlwrapper.NullFloat64
 	}{
 		{
 			"三振率算出",
@@ -103,8 +104,11 @@ func TestTeamBatting_SetStrikeOutRate(t *testing.T) {
 				StrikeOut:       10,
 				PlateAppearance: 100,
 			},
-			sql.NullFloat64{
-				Float64: 0.1,
+			sqlwrapper.NullFloat64{
+				NullFloat64: sql.NullFloat64{
+					Float64: 0.1,
+					Valid:   true,
+				},
 			},
 		},
 		{
@@ -113,8 +117,11 @@ func TestTeamBatting_SetStrikeOutRate(t *testing.T) {
 				StrikeOut:       0,
 				PlateAppearance: 0,
 			},
-			sql.NullFloat64{
-				Float64: 0.0,
+			sqlwrapper.NullFloat64{
+				NullFloat64: sql.NullFloat64{
+					Float64: 0.0,
+					Valid:   true,
+				},
 			},
 		},
 	}

--- a/entity/team/team_test.go
+++ b/entity/team/team_test.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,6 +87,41 @@ func TestTeamPitching_SetStrikeOutRate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.teamPitching.SetStrikeOutRate()
 			assert.Equal(t, tt.wantSetStrikeOutRate, tt.teamPitching.StrikeOutRate)
+		})
+	}
+}
+
+func TestTeamBatting_SetStrikeOutRate(t *testing.T) {
+	tests := []struct {
+		name              string
+		teamBatting       *TeamBatting
+		wantStrikeOutRate sql.NullFloat64
+	}{
+		{
+			"三振率算出",
+			&TeamBatting{
+				StrikeOut:       10,
+				PlateAppearance: 100,
+			},
+			sql.NullFloat64{
+				Float64: 0.1,
+			},
+		},
+		{
+			"三振率がNaN",
+			&TeamBatting{
+				StrikeOut:       0,
+				PlateAppearance: 0,
+			},
+			sql.NullFloat64{
+				Float64: 0.0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.teamBatting.SetStrikeOutRate()
+			assert.Equal(t, tt.wantStrikeOutRate, tt.teamBatting.StrikeOutRate)
 		})
 	}
 }

--- a/frontend/src/__test__/components/pages/__snapshots__/BattingPage.test.tsx.snap
+++ b/frontend/src/__test__/components/pages/__snapshots__/BattingPage.test.tsx.snap
@@ -703,6 +703,42 @@ exports[`打撃成績ページテスト スナップショット作成 1`] = `
                   role="button"
                   tabIndex={0}
                 >
+                  三振率
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
                   出塁率
                   <svg
                     aria-hidden={true}
@@ -1135,6 +1171,42 @@ exports[`打撃成績ページテスト スナップショット作成 1`] = `
                   tabIndex={0}
                 >
                   三振
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </th>
+              <th
+                aria-sort={null}
+                className="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight"
+                scope="col"
+              >
+                <span
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiTableSortLabel-root"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  三振率
                   <svg
                     aria-hidden={true}
                     className="MuiSvgIcon-root MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc"

--- a/frontend/src/components/pages/BattingPage.tsx
+++ b/frontend/src/components/pages/BattingPage.tsx
@@ -13,6 +13,7 @@ interface BattingData {
   homeRun: number;
   baseOnBalls: number;
   strikeOut: number;
+  strikeOutRate: number;
   onBasePercentage: number;
   babip: number;
 }
@@ -26,6 +27,7 @@ const headCells: HeadCell[] = [
   { id: 'homeRun', numeric: true, disablePadding: false, label: '本塁打' },
   { id: 'baseOnBalls', numeric: true, disablePadding: false, label: '四球' },
   { id: 'strikeOut', numeric: true, disablePadding: false, label: '三振' },
+  { id: 'strikeOutRate', numeric: true, disablePadding: false, label: '三振率' },
   { id: 'onBasePercentage', numeric: true, disablePadding: false, label: '出塁率' },
   { id: 'babip', numeric: true, disablePadding: false, label: 'BABIP' },
 ];
@@ -39,6 +41,7 @@ function createBattingData(
   homeRun: number,
   baseOnBalls: number,
   strikeOut: number,
+  strikeOutRate: number,
   onBasePercentage: number,
   babip: number
 ) {
@@ -51,6 +54,7 @@ function createBattingData(
     homeRun,
     baseOnBalls,
     strikeOut,
+    strikeOutRate,
     onBasePercentage,
     babip,
   };
@@ -89,6 +93,7 @@ function createBattingDataList(
           val.HomeRun,
           val.BaseOnBalls,
           val.StrikeOut,
+          val.StrikeOutRate,
           val.OnBasePercentage,
           val.BABIP
         )

--- a/frontend/src/components/pages/PlayerPage.tsx
+++ b/frontend/src/components/pages/PlayerPage.tsx
@@ -19,6 +19,7 @@ interface BattingDate {
   sluggingPercentage: number;
   homeRun: number;
   strikeOut: number;
+  strikeOutRate: number;
   groundedIntoDoublePlay: number;
   woba: number;
   rc: number;
@@ -34,6 +35,7 @@ const batterHeadCells: HeadCell[] = [
   { id: 'sluggingPercentage', numeric: true, disablePadding: true, label: '長打率' },
   { id: 'homeRun', numeric: true, disablePadding: true, label: '本塁打' },
   { id: 'strikeOut', numeric: true, disablePadding: true, label: '三振' },
+  { id: 'strikeOutRate', numeric: true, disablePadding: true, label: '三振率' },
   { id: 'groundedIntoDoublePlay', numeric: true, disablePadding: true, label: '併殺打' },
   { id: 'woba', numeric: true, disablePadding: true, label: '加重出塁率' },
   { id: 'rc', numeric: true, disablePadding: true, label: '創出得点' },
@@ -50,6 +52,7 @@ function createBattingDatas(
     SluggingPercentage: string;
     HomeRun: string;
     StrikeOut: string;
+    StrikeOutRate: string;
     GroundedIntoDoublePlay: string;
     Woba: string;
     RC: string;
@@ -67,6 +70,7 @@ function createBattingDatas(
       sluggingPercentage: Number(batting.SluggingPercentage),
       homeRun: Number(batting.HomeRun),
       strikeOut: Number(batting.StrikeOut),
+      strikeOutRate: Number(batting.StrikeOutRate),
       groundedIntoDoublePlay: Number(batting.GroundedIntoDoublePlay),
       woba: Number(batting.Woba),
       rc: Number(batting.RC),
@@ -147,6 +151,7 @@ interface BattingChartData {
   onBasePercentage: number;
   battingAverage: number;
   sluggingPercentage: number;
+  strikeOutRate: number;
 }
 
 function createBattingChartDatas(
@@ -155,6 +160,7 @@ function createBattingChartDatas(
     OnBasePercentage: string;
     BattingAverage: string;
     SluggingPercentage: string;
+    StrikeOutRate: string;
   }[]
 ) {
   const battings: BattingChartData[] = [];
@@ -165,6 +171,7 @@ function createBattingChartDatas(
         onBasePercentage: Number(batting.OnBasePercentage),
         battingAverage: Number(batting.BattingAverage),
         sluggingPercentage: Number(batting.SluggingPercentage),
+        strikeOutRate: Number(batting.StrikeOutRate),
       });
     }
   });
@@ -175,6 +182,7 @@ const battingChartData: ChartData[] = [
   { key: 'onBasePercentage', name: '出塁率', stroke: '#FF4F02' },
   { key: 'battingAverage', name: '打率', stroke: '#00FFFF' },
   { key: 'sluggingPercentage', name: '長打率', stroke: '#FF0461' },
+  { key: 'strikeOutRate', name: '三振率', stroke: '#000055' },
 ];
 
 interface PitchingEarnedRunAverageChartData {

--- a/grades/grades.go
+++ b/grades/grades.go
@@ -132,6 +132,7 @@ func (Interactor *GradesInteractor) InsertBatterGrades(batterMap map[string][]da
 			setWoba(&batter, config)
 			batter.SetRC()
 			batter.SetBABIP()
+			batter.SetStrikeOutRate()
 			Interactor.GradesRepository.InsertBatterGrades(key, batter)
 		}
 	}

--- a/infrastructure/grades_repository.go
+++ b/infrastructure/grades_repository.go
@@ -54,13 +54,7 @@ func (Repository *GradesRepository) GetBattings(playerID string) (battings []dat
 	for rows.Next() {
 		var playerID string
 		var batting data.BATTERGRADES
-		rows.Scan(&playerID, &batting.Year, &batting.TeamID, &batting.Team, &batting.Games,
-			&batting.PlateAppearance, &batting.AtBat, &batting.Score, &batting.Hit, &batting.Single,
-			&batting.Double, &batting.Triple, &batting.HomeRun, &batting.BaseHit,
-			&batting.RunsBattedIn, &batting.StolenBase, &batting.CaughtStealing, &batting.SacrificeHits,
-			&batting.SacrificeFlies, &batting.BaseOnBalls, &batting.HitByPitches, &batting.StrikeOut,
-			&batting.GroundedIntoDoublePlay, &batting.BattingAverage, &batting.SluggingPercentage, &batting.OnBasePercentage,
-			&batting.Woba, &batting.RC, &batting.BABIP)
+		rows.Scan(&playerID, &batting.Year, &batting.TeamID, &batting.Team, &batting.Games, &batting.PlateAppearance, &batting.AtBat, &batting.Score, &batting.Hit, &batting.Single, &batting.Double, &batting.Triple, &batting.HomeRun, &batting.BaseHit, &batting.RunsBattedIn, &batting.StolenBase, &batting.CaughtStealing, &batting.SacrificeHits, &batting.SacrificeFlies, &batting.BaseOnBalls, &batting.HitByPitches, &batting.StrikeOut, &batting.StrikeOutRate, &batting.GroundedIntoDoublePlay, &batting.BattingAverage, &batting.SluggingPercentage, &batting.OnBasePercentage, &batting.Woba, &batting.RC, &batting.BABIP)
 
 		battings = append(battings, batting)
 	}

--- a/infrastructure/grades_repository.go
+++ b/infrastructure/grades_repository.go
@@ -226,14 +226,14 @@ func (Repository *GradesRepository) ExtractionBatterGrades(batterMap *map[string
 
 // InsertBatterGrades 引数で受け取ったBATTERGRADESをDBに登録する
 func (Repository *GradesRepository) InsertBatterGrades(playerID string, batterGrades data.BATTERGRADES) {
-	stmt, err := Repository.Conn.Prepare("INSERT INTO batter_grades(player_id, year, team_id, team, games, plate_appearance, at_bat, score, hit, single, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, hit_by_pitches, strike_out, grounded_into_double_play, batting_average, slugging_percentage, on_base_percentage, w_oba, rc, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29)")
+	stmt, err := Repository.Conn.Prepare("INSERT INTO batter_grades(player_id, year, team_id, team, games, plate_appearance, at_bat, score, hit, single, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, hit_by_pitches, strike_out, strike_out_rate, grounded_into_double_play, batting_average, slugging_percentage, on_base_percentage, w_oba, rc, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
 
 	// 加重出塁率の計算に必要なconfigファイルを読み込む
-	if _, err := stmt.Exec(playerID, batterGrades.Year, batterGrades.TeamID, batterGrades.Team, batterGrades.Games, batterGrades.PlateAppearance, batterGrades.AtBat, batterGrades.Score, batterGrades.Hit, batterGrades.Single, batterGrades.Double, batterGrades.Triple, batterGrades.HomeRun, batterGrades.BaseHit, batterGrades.RunsBattedIn, batterGrades.StolenBase, batterGrades.CaughtStealing, batterGrades.SacrificeHits, batterGrades.SacrificeFlies, batterGrades.BaseOnBalls, batterGrades.HitByPitches, batterGrades.StrikeOut, batterGrades.GroundedIntoDoublePlay, batterGrades.BattingAverage, batterGrades.SluggingPercentage, batterGrades.OnBasePercentage, batterGrades.Woba, batterGrades.RC, batterGrades.BABIP); err != nil {
+	if _, err := stmt.Exec(playerID, batterGrades.Year, batterGrades.TeamID, batterGrades.Team, batterGrades.Games, batterGrades.PlateAppearance, batterGrades.AtBat, batterGrades.Score, batterGrades.Hit, batterGrades.Single, batterGrades.Double, batterGrades.Triple, batterGrades.HomeRun, batterGrades.BaseHit, batterGrades.RunsBattedIn, batterGrades.StolenBase, batterGrades.CaughtStealing, batterGrades.SacrificeHits, batterGrades.SacrificeFlies, batterGrades.BaseOnBalls, batterGrades.HitByPitches, batterGrades.StrikeOut, batterGrades.StrikeOutRate, batterGrades.GroundedIntoDoublePlay, batterGrades.BattingAverage, batterGrades.SluggingPercentage, batterGrades.OnBasePercentage, batterGrades.Woba, batterGrades.RC, batterGrades.BABIP); err != nil {
 		fmt.Println(playerID + ":" + batterGrades.Year)
 		log.Print(err)
 	}

--- a/infrastructure/grades_repository_test.go
+++ b/infrastructure/grades_repository_test.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"database/sql"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -92,7 +93,7 @@ func TestGradesRepository_InsertBatterGrades_GetBattings(t *testing.T) {
 			"打者成績登録と取得",
 			args{
 				"01605136",
-				createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3),
+				createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 0.3, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3),
 			},
 		},
 	}
@@ -113,11 +114,11 @@ func TestGradesRepository_InsertBatterGrades_GetBattings(t *testing.T) {
 
 func createBatterGradesList() []data.BATTERGRADES {
 	return []data.BATTERGRADES{
-		createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3),
+		createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 0.3, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3),
 	}
 }
 
-func createBatterGrades(Year string, TeamID string, Team string, Games int, PlateAppearance int, AtBat int, Score int, Hit int, Single int, Double int, Triple int, HomeRun int, BaseHit int, RunsBattedIn int, StolenBase int, CaughtStealing int, SacrificeHits int, SacrificeFlies int, BaseOnBalls int, HitByPitches int, StrikeOut int, GroundedIntoDoublePlay int, BattingAverage float64, SluggingPercentage float64, OnBasePercentage float64, Woba float64, RC float64, BABIP float64) data.BATTERGRADES {
+func createBatterGrades(Year string, TeamID string, Team string, Games int, PlateAppearance int, AtBat int, Score int, Hit int, Single int, Double int, Triple int, HomeRun int, BaseHit int, RunsBattedIn int, StolenBase int, CaughtStealing int, SacrificeHits int, SacrificeFlies int, BaseOnBalls int, HitByPitches int, StrikeOut int, StrikeOutRate float64, GroundedIntoDoublePlay int, BattingAverage float64, SluggingPercentage float64, OnBasePercentage float64, Woba float64, RC float64, BABIP float64) data.BATTERGRADES {
 	return data.BATTERGRADES{
 		Year:                   Year,
 		TeamID:                 TeamID,
@@ -140,6 +141,7 @@ func createBatterGrades(Year string, TeamID string, Team string, Games int, Plat
 		BaseOnBalls:            BaseOnBalls,
 		HitByPitches:           HitByPitches,
 		StrikeOut:              StrikeOut,
+		StrikeOutRate:          sql.NullFloat64{Float64: StrikeOutRate, Valid: true},
 		GroundedIntoDoublePlay: GroundedIntoDoublePlay,
 		BattingAverage:         BattingAverage,
 		SluggingPercentage:     SluggingPercentage,
@@ -326,7 +328,7 @@ func TestGradesRepository_ExtractionPicherGrades(t *testing.T) {
 }
 
 func TestGradesRepository_ExtractionBatterGrades(t *testing.T) {
-	batter := createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3)
+	batter := createBatterGrades("2018", "12", "オリックス", 113, 345, 295, 39, 78, 0, 8, 4, 1, 97, 15, 16, 9, 16, 0, 31, 3, 33, 0.3, 2, 0.264, 0.328, 0.34, 0.351, 60.2, 0.3)
 	prayerID := "01605136"
 	type args struct {
 		prayerID string

--- a/infrastructure/grades_repository_test.go
+++ b/infrastructure/grades_repository_test.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	data "github.com/tokuchi765/npb-analysis/entity/player"
+	"github.com/tokuchi765/npb-analysis/entity/sqlwrapper"
 	testUtil "github.com/tokuchi765/npb-analysis/test"
 )
 
@@ -141,7 +142,7 @@ func createBatterGrades(Year string, TeamID string, Team string, Games int, Plat
 		BaseOnBalls:            BaseOnBalls,
 		HitByPitches:           HitByPitches,
 		StrikeOut:              StrikeOut,
-		StrikeOutRate:          sql.NullFloat64{Float64: StrikeOutRate, Valid: true},
+		StrikeOutRate:          sqlwrapper.NullFloat64{NullFloat64: sql.NullFloat64{Float64: StrikeOutRate, Valid: true}},
 		GroundedIntoDoublePlay: GroundedIntoDoublePlay,
 		BattingAverage:         BattingAverage,
 		SluggingPercentage:     SluggingPercentage,

--- a/infrastructure/team_repository.go
+++ b/infrastructure/team_repository.go
@@ -124,12 +124,7 @@ func (Repository *TeamRepository) GetTeamBattings(years []int) (teamBattingMap m
 		var teamBattins []teamData.TeamBatting
 		for rows.Next() {
 			var teamBatting teamData.TeamBatting
-			rows.Scan(&teamBatting.TeamID, &teamBatting.Year, &teamBatting.BattingAverage, &teamBatting.Games, &teamBatting.PlateAppearance,
-				&teamBatting.AtBat, &teamBatting.Score, &teamBatting.Hit, &teamBatting.Double, &teamBatting.Triple, &teamBatting.HomeRun,
-				&teamBatting.BaseHit, &teamBatting.RunsBattedIn, &teamBatting.StolenBase, &teamBatting.CaughtStealing, &teamBatting.SacrificeHits,
-				&teamBatting.SacrificeFlies, &teamBatting.BaseOnBalls, &teamBatting.IntentionalWalk, &teamBatting.HitByPitches, &teamBatting.StrikeOut,
-				&teamBatting.GroundedIntoDoublePlay, &teamBatting.SluggingPercentage, &teamBatting.OnBasePercentage, &teamBatting.BABIP,
-			)
+			rows.Scan(&teamBatting.TeamID, &teamBatting.Year, &teamBatting.BattingAverage, &teamBatting.Games, &teamBatting.PlateAppearance, &teamBatting.AtBat, &teamBatting.Score, &teamBatting.Hit, &teamBatting.Double, &teamBatting.Triple, &teamBatting.HomeRun, &teamBatting.BaseHit, &teamBatting.RunsBattedIn, &teamBatting.StolenBase, &teamBatting.CaughtStealing, &teamBatting.SacrificeHits, &teamBatting.SacrificeFlies, &teamBatting.BaseOnBalls, &teamBatting.IntentionalWalk, &teamBatting.HitByPitches, &teamBatting.StrikeOut, &teamBatting.StrikeOutRate, &teamBatting.GroundedIntoDoublePlay, &teamBatting.SluggingPercentage, &teamBatting.OnBasePercentage, &teamBatting.BABIP)
 			teamBattins = append(teamBattins, teamBatting)
 		}
 
@@ -139,7 +134,7 @@ func (Repository *TeamRepository) GetTeamBattings(years []int) (teamBattingMap m
 	return teamBattingMap
 }
 
-// GetTeamBattingByTeamIDAndYear 引数で受け取ったチームIDと年に紐づくチーム投手成績を取得します。
+// GetTeamBattingByTeamIDAndYear 引数で受け取ったチームIDと年に紐づくチーム野手成績を取得します。
 func (Repository *TeamRepository) GetTeamBattingByTeamIDAndYear(teamID string, year string) (teamBatting teamData.TeamBatting) {
 	rows, err := Repository.SQLHandler.Conn.Query("select * from team_batting where year = $1 and team_id = $2", year, teamID)
 	defer rows.Close()
@@ -147,7 +142,7 @@ func (Repository *TeamRepository) GetTeamBattingByTeamIDAndYear(teamID string, y
 		fmt.Println(err)
 	}
 	for rows.Next() {
-		rows.Scan(&teamBatting.TeamID, &teamBatting.Year, &teamBatting.BattingAverage, &teamBatting.Games, &teamBatting.PlateAppearance, &teamBatting.AtBat, &teamBatting.Score, &teamBatting.Hit, &teamBatting.Double, &teamBatting.Triple, &teamBatting.HomeRun, &teamBatting.BaseHit, &teamBatting.RunsBattedIn, &teamBatting.StolenBase, &teamBatting.CaughtStealing, &teamBatting.SacrificeHits, &teamBatting.SacrificeFlies, &teamBatting.BaseOnBalls, &teamBatting.IntentionalWalk, &teamBatting.HitByPitches, &teamBatting.StrikeOut, &teamBatting.GroundedIntoDoublePlay, &teamBatting.SluggingPercentage, &teamBatting.OnBasePercentage, &teamBatting.BABIP)
+		rows.Scan(&teamBatting.TeamID, &teamBatting.Year, &teamBatting.BattingAverage, &teamBatting.Games, &teamBatting.PlateAppearance, &teamBatting.AtBat, &teamBatting.Score, &teamBatting.Hit, &teamBatting.Double, &teamBatting.Triple, &teamBatting.HomeRun, &teamBatting.BaseHit, &teamBatting.RunsBattedIn, &teamBatting.StolenBase, &teamBatting.CaughtStealing, &teamBatting.SacrificeHits, &teamBatting.SacrificeFlies, &teamBatting.BaseOnBalls, &teamBatting.IntentionalWalk, &teamBatting.HitByPitches, &teamBatting.StrikeOut, &teamBatting.StrikeOutRate, &teamBatting.GroundedIntoDoublePlay, &teamBatting.SluggingPercentage, &teamBatting.OnBasePercentage, &teamBatting.BABIP)
 	}
 	return teamBatting
 }

--- a/infrastructure/team_repository.go
+++ b/infrastructure/team_repository.go
@@ -98,12 +98,12 @@ func (Repository *TeamRepository) GetTeamPitchingMin() (minStrikeOutRate float64
 
 // InsertTeamBattings チーム打撃成績をDBに登録する
 func (Repository *TeamRepository) InsertTeamBattings(batting teamData.TeamBatting) {
-	stmt, err := Repository.Conn.Prepare("INSERT INTO team_batting(team_id, year, batting_average, games, plate_appearance, at_bat, score, hit, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, intentional_walk, hit_by_pitches, strike_out, grounded_into_double_play, slugging_percentage, on_base_percentage, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)")
+	stmt, err := Repository.Conn.Prepare("INSERT INTO team_batting(team_id, year, batting_average, games, plate_appearance, at_bat, score, hit, double, triple, home_run, base_hit, runs_batted_in, stolen_base, caught_stealing, sacrifice_hits, sacrifice_flies, base_on_balls, intentional_walk, hit_by_pitches, strike_out, strike_out_rate, grounded_into_double_play, slugging_percentage, on_base_percentage, babip) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)")
 	if err != nil {
 		log.Print(err)
 	}
 	defer stmt.Close()
-	if _, err := stmt.Exec(batting.TeamID, batting.Year, batting.BattingAverage, batting.Games, batting.PlateAppearance, batting.AtBat, batting.Score, batting.Hit, batting.Double, batting.Triple, batting.HomeRun, batting.BaseHit, batting.RunsBattedIn, batting.StolenBase, batting.CaughtStealing, batting.SacrificeHits, batting.SacrificeFlies, batting.BaseOnBalls, batting.IntentionalWalk, batting.HitByPitches, batting.StrikeOut, batting.GroundedIntoDoublePlay, batting.SluggingPercentage, batting.OnBasePercentage, batting.BABIP); err != nil {
+	if _, err := stmt.Exec(batting.TeamID, batting.Year, batting.BattingAverage, batting.Games, batting.PlateAppearance, batting.AtBat, batting.Score, batting.Hit, batting.Double, batting.Triple, batting.HomeRun, batting.BaseHit, batting.RunsBattedIn, batting.StolenBase, batting.CaughtStealing, batting.SacrificeHits, batting.SacrificeFlies, batting.BaseOnBalls, batting.IntentionalWalk, batting.HitByPitches, batting.StrikeOut, batting.StrikeOutRate, batting.GroundedIntoDoublePlay, batting.SluggingPercentage, batting.OnBasePercentage, batting.BABIP); err != nil {
 		fmt.Println(batting.TeamID + ":" + batting.Year)
 		log.Print(err)
 	}

--- a/infrastructure/team_repository_test.go
+++ b/infrastructure/team_repository_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tokuchi765/npb-analysis/entity/sqlwrapper"
 	teamData "github.com/tokuchi765/npb-analysis/entity/team"
 	testUtil "github.com/tokuchi765/npb-analysis/test"
 )
@@ -132,7 +133,7 @@ func createTeamBatting(teamID string, year string, battingAverage float64, games
 		IntentionalWalk:        intentionalWalk,
 		HitByPitches:           hitByPitches,
 		StrikeOut:              strikeOut,
-		StrikeOutRate:          sql.NullFloat64{Float64: strikeOutRate, Valid: true},
+		StrikeOutRate:          sqlwrapper.NullFloat64{NullFloat64: sql.NullFloat64{Float64: strikeOutRate, Valid: true}},
 		GroundedIntoDoublePlay: groundedIntoDoublePlay,
 		SluggingPercentage:     sluggingPercentage,
 		OnBasePercentage:       onBasePercentage,

--- a/infrastructure/team_repository_test.go
+++ b/infrastructure/team_repository_test.go
@@ -86,7 +86,7 @@ func TestTeamInteractor_InsertTeamBattings_GetTeamBatting(t *testing.T) {
 		{
 			"チーム打撃成績取得と登録",
 			args{
-				teamBatting: createTeamBatting("01", "2005", 0.301, 144, 360, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 20, 0.21, 0.314, 0.3),
+				teamBatting: createTeamBatting("01", "2005", 0.301, 144, 360, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 0.3, 20, 0.21, 0.314, 0.3),
 			},
 		},
 	}
@@ -109,7 +109,7 @@ func TestTeamInteractor_InsertTeamBattings_GetTeamBatting(t *testing.T) {
 	}
 }
 
-func createTeamBatting(teamID string, year string, battingAverage float64, games int, plateAppearance int, atBat int, score int, hit int, double int, triple int, homeRun int, baseHit int, runsBattedIn int, stolenBase int, caughtStealing int, sacrificeHits int, sacrificeFlies int, baseOnBalls int, intentionalWalk int, hitByPitches int, strikeOut int, groundedIntoDoublePlay int, sluggingPercentage float64, onBasePercentage float64, babip float64) teamData.TeamBatting {
+func createTeamBatting(teamID string, year string, battingAverage float64, games int, plateAppearance int, atBat int, score int, hit int, double int, triple int, homeRun int, baseHit int, runsBattedIn int, stolenBase int, caughtStealing int, sacrificeHits int, sacrificeFlies int, baseOnBalls int, intentionalWalk int, hitByPitches int, strikeOut int, strikeOutRate float64, groundedIntoDoublePlay int, sluggingPercentage float64, onBasePercentage float64, babip float64) teamData.TeamBatting {
 	return teamData.TeamBatting{
 		TeamID:                 teamID,
 		Year:                   year,
@@ -132,6 +132,7 @@ func createTeamBatting(teamID string, year string, battingAverage float64, games
 		IntentionalWalk:        intentionalWalk,
 		HitByPitches:           hitByPitches,
 		StrikeOut:              strikeOut,
+		StrikeOutRate:          sql.NullFloat64{Float64: strikeOutRate, Valid: true},
 		GroundedIntoDoublePlay: groundedIntoDoublePlay,
 		SluggingPercentage:     sluggingPercentage,
 		OnBasePercentage:       onBasePercentage,
@@ -491,7 +492,7 @@ func TestTeamRepository_GetTeamBattingByTeamIDAndYear(t *testing.T) {
 				"01",
 				"2005",
 			},
-			createTeamBatting("01", "2005", 0.301, 144, 360, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 20, 0.21, 0.314, 0.3),
+			createTeamBatting("01", "2005", 0.301, 144, 360, 360, 400, 360, 90, 5, 70, 400, 400, 50, 20, 20, 20, 100, 100, 100, 100, 0.3, 20, 0.21, 0.314, 0.3),
 		},
 	}
 	for _, tt := range tests {
@@ -532,9 +533,9 @@ func TestTeamRepository_GetTeamBattingMax(t *testing.T) {
 			sqlHandler.Conn = db
 			repository := TeamRepository{SQLHandler: *sqlHandler}
 
-			repository.InsertTeamBattings(createTeamBatting("01", "2005", 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.67, 0.451, 0))
-			repository.InsertTeamBattings(createTeamBatting("05", "2007", 0, 0, 0, 0, 0, 0, 0, 0, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.21, 0.314, 0))
-			repository.InsertTeamBattings(createTeamBatting("11", "2015", 0, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.30, 0.531, 0))
+			repository.InsertTeamBattings(createTeamBatting("01", "2005", 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.67, 0.451, 0))
+			repository.InsertTeamBattings(createTeamBatting("05", "2007", 0, 0, 0, 0, 0, 0, 0, 0, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.21, 0.314, 0))
+			repository.InsertTeamBattings(createTeamBatting("11", "2015", 0, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.30, 0.531, 0))
 
 			maxHomeRun, maxSluggingPercentage, maxOnBasePercentage := repository.GetTeamBattingMax()
 			assert.Equal(t, tt.wantMaxHomeRun, maxHomeRun)
@@ -567,9 +568,9 @@ func TestTeamRepository_GetTeamBattingMin(t *testing.T) {
 			sqlHandler.Conn = db
 			repository := TeamRepository{SQLHandler: *sqlHandler}
 
-			repository.InsertTeamBattings(createTeamBatting("01", "2005", 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.67, 0.451, 0))
-			repository.InsertTeamBattings(createTeamBatting("05", "2007", 0, 0, 0, 0, 0, 0, 0, 0, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.21, 0.314, 0))
-			repository.InsertTeamBattings(createTeamBatting("11", "2015", 0, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.30, 0.531, 0))
+			repository.InsertTeamBattings(createTeamBatting("01", "2005", 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.67, 0.451, 0))
+			repository.InsertTeamBattings(createTeamBatting("05", "2007", 0, 0, 0, 0, 0, 0, 0, 0, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.21, 0.314, 0))
+			repository.InsertTeamBattings(createTeamBatting("11", "2015", 0, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.30, 0.531, 0))
 
 			minHomeRun, minSluggingPercentage, minOnBasePercentage := repository.GetTeamBattingMin()
 

--- a/team/team.go
+++ b/team/team.go
@@ -126,6 +126,7 @@ func (Interactor *TeamInteractor) InsertTeamBattings(csvPath string, league stri
 		teamBatting := Interactor.ReadTeamBatting(csvPath, league, strconv.Itoa(year))
 		for _, batting := range teamBatting {
 			batting.SetBABIP()
+			batting.SetStrikeOutRate()
 			Interactor.TeamRepository.InsertTeamBattings(batting)
 		}
 	}


### PR DESCRIPTION
# 機能追加
- 打撃成績ページ
![image](https://user-images.githubusercontent.com/55987154/173357993-adfd29c8-f97f-4858-8700-4429c69e5896.png)
- 個人成績ページ
  - グラフ
![image](https://user-images.githubusercontent.com/55987154/173358501-49c3140f-4a7c-4c85-863e-3672564c8bc0.png)
  - テーブル
![image](https://user-images.githubusercontent.com/55987154/173358592-d4f1c3b8-23f8-4e6b-a417-d493b2462899.png)

# Issue起票
- https://github.com/tokuchi765/npb-analysis/issues/39